### PR TITLE
Add support for TCP connections

### DIFF
--- a/dsmr_parser/__main__.py
+++ b/dsmr_parser/__main__.py
@@ -1,8 +1,9 @@
 import argparse
 import asyncio
 import logging
+from functools import partial
 
-from .protocol import create_dsmr_reader
+from .protocol import create_dsmr_reader, create_tcp_dsmr_reader
 
 
 def console():
@@ -11,6 +12,10 @@ def console():
     parser = argparse.ArgumentParser(description=console.__doc__)
     parser.add_argument('--device', default='/dev/ttyUSB0',
                         help='port to read DSMR data from')
+    parser.add_argument('--host', default=None,
+                        help='alternatively connect using TCP host.')
+    parser.add_argument('--port', default=None,
+                        help='TCP port to use for connection')
     parser.add_argument('--version', default='2.2', choices=['2.2', '4'],
                         help='DSMR version (2.2, 4)')
     parser.add_argument('--verbose', '-v', action='count')
@@ -32,7 +37,29 @@ def console():
                 print(obj.value, obj.unit)
         print()
 
-    conn = create_dsmr_reader(args.device, args.version, print_callback, loop=loop)
+    # create tcp or serial connection depending on args
+    if args.host and args.port:
+        create_connection = partial(create_tcp_dsmr_reader,
+                                    args.host, args.port, args.version,
+                                    print_callback, loop=loop)
+    else:
+        create_connection = partial(create_dsmr_reader,
+                                    args.device, args.version,
+                                    print_callback, loop=loop)
 
-    loop.create_task(conn)
-    loop.run_forever()
+    try:
+        # connect and keep connected until interrupted by ctrl-c
+        while True:
+            # create serial or tcp connection
+            conn = create_connection()
+            transport, protocol = loop.run_until_complete(conn)
+            # wait until connection it closed
+            loop.run_until_complete(protocol.wait_closed())
+            # wait 5 seconds before attempting reconnect
+            loop.run_until_complete(asyncio.sleep(5))
+    except KeyboardInterrupt:
+        # cleanup connection after user initiated shutdown
+        transport.close()
+        loop.run_until_complete(asyncio.sleep(0))
+    finally:
+        loop.close()

--- a/dsmr_parser/protocol.py
+++ b/dsmr_parser/protocol.py
@@ -13,7 +13,7 @@ from .serial import (SERIAL_SETTINGS_V2_2, SERIAL_SETTINGS_V4,
                      is_end_of_telegram, is_start_of_telegram)
 
 
-def creater_dsmr_protocol(dsmr_version, telegram_callback, loop=None):
+def create_dsmr_protocol(dsmr_version, telegram_callback, loop=None):
     """Creates a DSMR asyncio protocol."""
 
     if dsmr_version == '2.2':
@@ -33,7 +33,7 @@ def creater_dsmr_protocol(dsmr_version, telegram_callback, loop=None):
 
 def create_dsmr_reader(port, dsmr_version, telegram_callback, loop=None):
     """Creates a DSMR asyncio protocol coroutine using serial port."""
-    protocol, serial_settings = creater_dsmr_protocol(
+    protocol, serial_settings = create_dsmr_protocol(
         dsmr_version, telegram_callback, loop=None)
     serial_settings['url'] = port
 
@@ -44,7 +44,7 @@ def create_dsmr_reader(port, dsmr_version, telegram_callback, loop=None):
 def create_tcp_dsmr_reader(host, port, dsmr_version,
                            telegram_callback, loop=None):
     """Creates a DSMR asyncio protocol coroutine using TCP connection."""
-    protocol, _ = creater_dsmr_protocol(
+    protocol, _ = create_dsmr_protocol(
         dsmr_version, telegram_callback, loop=None)
     conn = loop.create_connection(protocol, host, port)
     return conn


### PR DESCRIPTION
This allows connections with TCP for example `ser2net`, `p1-wifi gateway` or when proxying from a RPi using `socat`: 

    socat /dev/ttyUSB0,b9600 TCP-LISTEN:1234,reuseaddr