### PR TITLE
Pass lines to parser including line endings

### DIFF
--- a/dsmr_parser/protocol.py
+++ b/dsmr_parser/protocol.py
@@ -77,7 +77,7 @@ class DSMRProtocol(asyncio.Protocol):
         while crlf in self.buffer:
             line, self.buffer = self.buffer.split(crlf, 1)
             self.log.debug('got line: %s', line)
-            line += crlf # add the trailing crlf again
+            line += crlf  # add the trailing crlf again
 
             # Telegrams need to be complete because the values belong to a
             # particular reading and can also be related to eachother.

--- a/dsmr_parser/protocol.py
+++ b/dsmr_parser/protocol.py
@@ -73,9 +73,11 @@ class DSMRProtocol(asyncio.Protocol):
 
     def handle_lines(self):
         """Assemble incoming data into single lines."""
-        while "\r\n" in self.buffer:
-            line, self.buffer = self.buffer.split("\r\n", 1)
+        crlf = "\r\n"
+        while crlf in self.buffer:
+            line, self.buffer = self.buffer.split(crlf, 1)
             self.log.debug('got line: %s', line)
+            line += crlf # add the trailing crlf again
 
             # Telegrams need to be complete because the values belong to a
             # particular reading and can also be related to eachother.


### PR DESCRIPTION
This PR will solve CRC issues for me when using the DSMRProtocol class. It effectively adds line feeds again after they've been stripped by split.