### PR TITLE
Add DSMR5 option to protocol.

### DIFF
--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -23,6 +23,9 @@ def create_dsmr_protocol(dsmr_version, telegram_callback, loop=None):
     elif dsmr_version == '4':
         specification = telegram_specifications.V4
         serial_settings = SERIAL_SETTINGS_V4
+    elif dsmr_version == '5':
+        specification = telegram_specifications.V5
+        serial_settings = SERIAL_SETTINGS_V4
     else:
         raise NotImplementedError("No telegram parser found for version: %s",
                                   dsmr_version)


### PR DESCRIPTION
This will allow support for: https://github.com/home-assistant/home-assistant/pull/7535

Currently i'm assuming V5 serial settings are equal to V4. I will ask users to test.