### PR TITLE
Support optional telegram signatures

### DIFF
--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -51,12 +51,10 @@ class TelegramParser(object):
         for signature, parser in self.telegram_specification['objects'].items():
             match = re.search(signature, telegram_data, re.DOTALL)
 
-            # All telegram specification lines/signatures are expected to be
-            # present.
-            if not match:
-                raise ParseError('Telegram specification does not match '
-                                 'telegram data')
-            telegram[signature] = parser.parse(match.group(0))
+            # Some signatures are optional and may not be present,
+            # so only parse lines that match
+            if match:
+                telegram[signature] = parser.parse(match.group(0))
 
         return telegram
 


### PR DESCRIPTION
This PR fixes #24 and adds support for optional signatures like the *_L2_* and *_L3_* ones (i.e. VOLTAGE_SAG_L2_COUNT). It just parses the ones that are present in the telegram data and doesn't care about missing ones.