### PR TITLE
Optional NUL after checksum

### DIFF
--- a/dsmr_parser/clients/telegram_buffer.py
+++ b/dsmr_parser/clients/telegram_buffer.py
@@ -51,7 +51,7 @@ class TelegramBuffer(object):
         # - The checksum is optional '{0,4}' because not all telegram versions
         # support it.
         return re.findall(
-            r'\/[^\/]+?\![A-F0-9]{0,4}\r\n',
+            r'\/[^\/]+?\![A-F0-9]{0,4}\0?\r\n',
             self._buffer,
             re.DOTALL
         )


### PR DESCRIPTION
Some smart meters can return 00 0D 0A after the checksum instead of just 0D 0A.