### PR TITLE
removing PYTZ dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  
+  - 3.7
+
 install: pip install tox-travis codecov
 
 script: tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ----------
 
+**0.12** (2018-07-12)
+
+- removed pytz dependency because of TZ caching in serverless application
+
 **0.11** (2017-09-18)
 
 - NULL value fix in checksum (`pull request #26 <https://github.com/ndokter/dsmr_parser/pull/26>`_)

--- a/dsmr_parser/value_types.py
+++ b/dsmr_parser/value_types.py
@@ -1,18 +1,31 @@
 import datetime
-
-import pytz
-
+from datetime import timezone
+import dateutil.parser
 
 def timestamp(value):
-    naive_datetime = datetime.datetime.strptime(value[:-1], '%y%m%d%H%M%S')
 
-    # TODO comment on this exception
+    # P1 Companion Standard v4.2.2 final
+    # see 5.4 Representation of COSEM objects
+    # YYMMDDhhmmssX, (X=S) or DST is not active (X=W).
+
     if len(value) == 13:
-        is_dst = value[12] == 'S'  # assume format 160322150000W
+        is_dst = value[12] == 'S'
     else:
+        # not specified
         is_dst = False
 
-    local_tz = pytz.timezone('Europe/Amsterdam')
-    localized_datetime = local_tz.localize(naive_datetime, is_dst=is_dst)
+    # create iso8601 format with as little help as possible
+    # 2018-07-11T08:13:33+00:00
+    iso8601_value = "20{year}-{month}-{day}T{hour}:{minute}:{second}+{offset}:00".format(
+        year=value[0:2],
+        month=value[2:4],
+        day=value[4:6],
+        hour=value[6:8],
+        minute=value[8:10],
+        second=value[10:12],
+        offset=('02' if is_dst else '01')
+    )
 
-    return localized_datetime.astimezone(pytz.utc)
+    d = dateutil.parser.parse(iso8601_value)
+
+    return d.astimezone(timezone.utc)

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ setup(
     author='Nigel Dokter',
     author_email='nigeldokter@gmail.com',
     url='https://github.com/ndokter/dsmr_parser',
-    version='0.11',
+    version='0.12',
     packages=find_packages(),
     install_requires=[
         'pyserial>=3,<4',
         'pyserial-asyncio<1',
-        'pytz',
+        'python-dateutil>=2',
         'PyCRC>=1.2,<2'
     ],
     entry_points={


### PR DESCRIPTION
Hi there,

We removed the PYTZ as we cannot create caches of TZs in AWS Lambda. The time/dst could use a testcase for different DMSR vendors (13 vs 12 chars), and W/S notations. 

cheers,
Martijn