### PR TITLE
Add serial settings for DSMR v5.0

### DIFF
--- a/dsmr_parser/clients/__init__.py
+++ b/dsmr_parser/clients/__init__.py
@@ -1,5 +1,5 @@
 from dsmr_parser.clients.settings import SERIAL_SETTINGS_V2_2, \
-    SERIAL_SETTINGS_V4
+    SERIAL_SETTINGS_V4, SERIAL_SETTINGS_V5
 from dsmr_parser.clients.serial_ import SerialReader, AsyncSerialReader
 from dsmr_parser.clients.protocol import create_dsmr_protocol, \
     create_dsmr_reader, create_tcp_dsmr_reader

--- a/dsmr_parser/clients/settings.py
+++ b/dsmr_parser/clients/settings.py
@@ -20,3 +20,13 @@ SERIAL_SETTINGS_V4 = {
     'rtscts': 0,
     'timeout': 20
 }
+
+SERIAL_SETTINGS_V5 = {
+    'baudrate': 115200,
+    'bytesize': serial.EIGHTBITS,
+    'parity': serial.PARITY_NONE,
+    'stopbits': serial.STOPBITS_ONE,
+    'xonxoff': 0,
+    'rtscts': 0,
+    'timeout': 20
+}


### PR DESCRIPTION
The serial settings for DSMR v5.0 are 115200 8N1 (see page 15 of https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf). Tested with a Sagemcom XS210.