### PR TITLE
Improve performance: read more data from serial port at once

### DIFF
--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -30,7 +30,7 @@ class SerialReader(object):
         """
         with serial.Serial(**self.serial_settings) as serial_handle:
             while True:
-                data = serial_handle.readline()
+                data = serial_handle.read(max(1, min(1024, serial_handle.in_waiting)))
                 self.telegram_buffer.append(data.decode('ascii'))
 
                 for telegram in self.telegram_buffer.get_all():


### PR DESCRIPTION
The CPU load of running a DSMR v5.0 client is around 10% for me on a Raspberry PI 3B. I ran a profiler to find out where all this time is spent. Since it turns out that it is somewhat expensive to read from the serial port, I tried to optimise this a bit. Reading out larger chunks of data helps performance significantly. I saw the CPU load drop by at least 50%.

See also pyserial/pyserial#216 and pyserial/pyserial#318.