### PR TITLE
Fix json serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Change Log
 ----------
+**0.21** (2020-05-25)
+
+- All objects can produce a json serialization of their state.
+
 **0.20** (2020-05-12)
 
 - All objects can now print their values

--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -140,6 +140,18 @@ class ProfileGenericObject(DSMRObject):
                 self._buffer_list.append(MBusObject([self.values[offset], self.values[offset + 1]]))
         return self._buffer_list
 
+    @property
+    def value(self):
+        list = [['buffer_length', self.buffer_length]]
+        list.append(['buffer_type', self.buffer_type])
+        buffer_repr = [
+            (['datetime', buffer_item.datetime],
+             ['value', buffer_item.value])
+            for buffer_item in self.buffer
+        ]
+        list.append(['buffer', buffer_repr])
+        return dict(list)
+
     def __str__(self):
         output = "\t buffer length: {}\n".format(self.buffer_length)
         output += "\t buffer type: {}".format(self.buffer_type)

--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -145,8 +145,8 @@ class ProfileGenericObject(DSMRObject):
         list = [['buffer_length', self.buffer_length]]
         list.append(['buffer_type', self.buffer_type])
         buffer_repr = [
-            (['datetime', buffer_item.datetime],
-             ['value', buffer_item.value])
+            dict([['datetime', buffer_item.datetime],
+             ['value', buffer_item.value]])
             for buffer_item in self.buffer
         ]
         list.append(['buffer', buffer_repr])

--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -1,5 +1,7 @@
 import dsmr_parser.obis_name_mapping
 import datetime
+import json
+from decimal import Decimal
 
 
 class Telegram(object):
@@ -52,6 +54,9 @@ class Telegram(object):
             output += "{}: \t {}\n".format(attr, str(value))
         return output
 
+    def to_json(self):
+        return json.dumps(dict([[attr, json.loads(value.to_json())] for attr, value in self]))
+
 
 class DSMRObject(object):
     """
@@ -92,6 +97,22 @@ class MBusObject(DSMRObject):
         output = "{}\t[{}] at {}".format(str(self.value), str(self.unit), str(self.datetime.astimezone().isoformat()))
         return output
 
+    def to_json(self):
+        timestamp = self.datetime
+        if isinstance(self.datetime, datetime.datetime):
+            timestamp = self.datetime.astimezone().isoformat()
+        value = self.value
+        if isinstance(self.value, datetime.datetime):
+            value = self.value.astimezone().isoformat()
+        if isinstance(self.value, Decimal):
+            value = float(self.value)
+        output = {
+            'datetime': timestamp,
+            'value': value,
+            'unit': self.unit
+        }
+        return json.dumps(output)
+
 
 class CosemObject(DSMRObject):
 
@@ -109,6 +130,18 @@ class CosemObject(DSMRObject):
             print_value = self.value.astimezone().isoformat()
         output = "{}\t[{}]".format(str(print_value), str(self.unit))
         return output
+
+    def to_json(self):
+        json_value = self.value
+        if isinstance(self.value, datetime.datetime):
+            json_value = self.value.astimezone().isoformat()
+        if isinstance(self.value, Decimal):
+            json_value = float(self.value)
+        output = {
+            'value': json_value,
+            'unit': self.unit
+        }
+        return json.dumps(output)
 
 
 class ProfileGenericObject(DSMRObject):
@@ -140,18 +173,6 @@ class ProfileGenericObject(DSMRObject):
                 self._buffer_list.append(MBusObject([self.values[offset], self.values[offset + 1]]))
         return self._buffer_list
 
-    @property
-    def value(self):
-        list = [['buffer_length', self.buffer_length]]
-        list.append(['buffer_type', self.buffer_type])
-        buffer_repr = [
-            dict([['datetime', buffer_item.datetime],
-             ['value', buffer_item.value]])
-            for buffer_item in self.buffer
-        ]
-        list.append(['buffer', buffer_repr])
-        return dict(list)
-
     def __str__(self):
         output = "\t buffer length: {}\n".format(self.buffer_length)
         output += "\t buffer type: {}".format(self.buffer_type)
@@ -162,3 +183,25 @@ class ProfileGenericObject(DSMRObject):
             output += "\n\t event occured at: {}".format(timestamp)
             output += "\t for: {} [{}]".format(buffer_value.value, buffer_value.unit)
         return output
+
+    def to_json(self):
+        """
+        :return: A json of all values in the GenericProfileObject , with the following structure
+                 {'buffer_length': n,
+                  'buffer_type': obis_ref,
+                  'buffer': [{'datetime': d1,
+                              'value': v1,
+                              'unit': u1},
+                              ...
+                               {'datetime': dn,
+                              'value': vn,
+                              'unit': un}
+                              ]
+                  }
+        """
+        list = [['buffer_length', self.buffer_length]]
+        list.append(['buffer_type', self.buffer_type])
+        buffer_repr = [json.loads(buffer_item.to_json()) for buffer_item in self.buffer]
+        list.append(['buffer', buffer_repr])
+        output = dict(list)
+        return json.dumps(output)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author='Nigel Dokter',
     author_email='nigel@nldr.net',
     url='https://github.com/ndokter/dsmr_parser',
-    version='0.20',
+    version='0.21',
     packages=find_packages(),
     install_requires=[
         'pyserial>=3,<4',


### PR DESCRIPTION
hi Nigel,
I reconsidered adding a value property to GenericProfileObject and dropped the idea.
Instead I added a to_json() method to all objects, so the objects can serialize themselves now to json. This solves my issue.

I would appreciate if you merge and release it.

Usage is simple:

```python
from dsmr_parser import telegram_specifications
from dsmr_parser.objects import Telegram
from dsmr_parser.parsers import TelegramParser
from example_telegrams import TELEGRAM_V4_2
parser = TelegramParser(telegram_specifications.V4)
telegram = Telegram(TELEGRAM_V4_2, parser, telegram_specifications.V4)

json_representation = telegram.to_json()

print(json.dumps(json.loads(json_representation), indent=4))
```
```output
{
    "P1_MESSAGE_HEADER": {
        "value": "42",
        "unit": null
    },
    "P1_MESSAGE_TIMESTAMP": {
        "value": "2016-11-13T20:57:57+01:00",
        "unit": null
    },
    "EQUIPMENT_IDENTIFIER": {
        "value": "3960221976967177082151037881335713",
        "unit": null
    },
    "ELECTRICITY_USED_TARIFF_1": {
        "value": 1581.123,
        "unit": "kWh"
    },
    "ELECTRICITY_USED_TARIFF_2": {
        "value": 1435.706,
        "unit": "kWh"
    },
    "ELECTRICITY_DELIVERED_TARIFF_1": {
        "value": 0.0,
        "unit": "kWh"
    },
    "ELECTRICITY_DELIVERED_TARIFF_2": {
        "value": 0.0,
        "unit": "kWh"
    },
    "ELECTRICITY_ACTIVE_TARIFF": {
        "value": "0002",
        "unit": null
    },
    "CURRENT_ELECTRICITY_USAGE": {
        "value": 2.027,
        "unit": "kW"
    },
    "CURRENT_ELECTRICITY_DELIVERY": {
        "value": 0.0,
        "unit": "kW"
    },
    "SHORT_POWER_FAILURE_COUNT": {
        "value": 15,
        "unit": null
    },
    "LONG_POWER_FAILURE_COUNT": {
        "value": 7,
        "unit": null
    },
    "POWER_EVENT_FAILURE_LOG": {
        "buffer_length": 3,
        "buffer_type": "0-0:96.7.19",
        "buffer": [
            {
                "datetime": "2000-01-04T18:03:20+01:00",
                "value": 237126,
                "unit": "s"
            },
            {
                "datetime": "2000-01-01T00:00:01+01:00",
                "value": 2147583646,
                "unit": "s"
            },
            {
                "datetime": "2000-01-02T00:00:03+01:00",
                "value": 2317482647,
                "unit": "s"
            }
        ]
    },
    "VOLTAGE_SAG_L1_COUNT": {
        "value": 0,
        "unit": null
    },
    "VOLTAGE_SAG_L2_COUNT": {
        "value": 0,
        "unit": null
    },
    "VOLTAGE_SAG_L3_COUNT": {
        "value": 0,
        "unit": null
    },
    "VOLTAGE_SWELL_L1_COUNT": {
        "value": 0,
        "unit": null
    },
    "VOLTAGE_SWELL_L2_COUNT": {
        "value": 0,
        "unit": null
    },
    "VOLTAGE_SWELL_L3_COUNT": {
        "value": 0,
        "unit": null
    },
    "TEXT_MESSAGE_CODE": {
        "value": null,
        "unit": null
    },
    "TEXT_MESSAGE": {
        "value": null,
        "unit": null
    },
    "DEVICE_TYPE": {
        "value": 3,
        "unit": null
    },
    "INSTANTANEOUS_CURRENT_L1": {
        "value": 0.0,
        "unit": "A"
    },
    "INSTANTANEOUS_CURRENT_L2": {
        "value": 6.0,
        "unit": "A"
    },
    "INSTANTANEOUS_CURRENT_L3": {
        "value": 2.0,
        "unit": "A"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE": {
        "value": 0.17,
        "unit": "kW"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE": {
        "value": 1.247,
        "unit": "kW"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE": {
        "value": 0.209,
        "unit": "kW"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE": {
        "value": 0.0,
        "unit": "kW"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE": {
        "value": 0.0,
        "unit": "kW"
    },
    "INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE": {
        "value": 0.0,
        "unit": "kW"
    },
    "EQUIPMENT_IDENTIFIER_GAS": {
        "value": "4819243993373755377509728609491464",
        "unit": null
    },
    "HOURLY_GAS_METER_READING": {
        "datetime": "2016-11-29T20:00:00+01:00",
        "value": 981.443,
        "unit": "m3"
    }
}
```

