### PR TITLE
fix for empty parentheses in ProfileGenericParser

### DIFF
--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -225,8 +225,11 @@ class ProfileGenericParser(DSMRObjectParser):
         self.parsers_for_unidentified = parsers_for_unidentified
 
     def _is_line_wellformed(self, line, values):
+        
+        # allow empty parentheses (indicated by empty string)
         if values and (len(values) == 1) and (values[0] == ''):
             return True
+
         if values and (len(values) >= 2) and (values[0].isdigit()):
             buffer_length = int(values[0])
             return (buffer_length <= 10) and (len(values) == (buffer_length * 2 + 2))
@@ -234,9 +237,10 @@ class ProfileGenericParser(DSMRObjectParser):
             return False
 
     def _parse_values(self, values):
+        # in case of empty parentheses return
         if values and (len(values) == 1) and (values[0] == None):
-            return [self.value_formats[i].parse(value)
-                for i, value in enumerate(values)]
+            return super()._parse_values(values) #calling parent
+
         buffer_length = int(values[0])
         buffer_value_obis_ID = values[1]
         if (buffer_length > 0):

--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -225,6 +225,8 @@ class ProfileGenericParser(DSMRObjectParser):
         self.parsers_for_unidentified = parsers_for_unidentified
 
     def _is_line_wellformed(self, line, values):
+        if values and (len(values) == 1) and (values[0] == ''):
+            return True
         if values and (len(values) >= 2) and (values[0].isdigit()):
             buffer_length = int(values[0])
             return (buffer_length <= 10) and (len(values) == (buffer_length * 2 + 2))
@@ -232,6 +234,9 @@ class ProfileGenericParser(DSMRObjectParser):
             return False
 
     def _parse_values(self, values):
+        if values and (len(values) == 1) and (values[0] == None):
+            return [self.value_formats[i].parse(value)
+                for i, value in enumerate(values)]
         buffer_length = int(values[0])
         buffer_value_obis_ID = values[1]
         if (buffer_length > 0):


### PR DESCRIPTION
With an iskra m550 I got the following exception:

```python
Failed to parse telegram: ("Invalid '%s' line for '%s'", '99.97.0()\r\n', <dsmr_parser.parsers.ProfileGenericParser object at 0x76814210>)
```

This is caused by empty parentheses `()`, which can't be handled by `ProfileGenericParser`. 


This fixes the issue for me: 

* make sure the `_is_line_wellformed` function returns true if there are empty parentheses; 
* if  `_is_line_wellformed`  returns `true`, the empty value will be turned into `None`
* since ` _parse_values` can't handle None values, I also added a check in `_parse_values`  ; if `None` is the case, call the parent function

