### PR TITLE
Do not install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email='nigel@nldr.net',
     url='https://github.com/ndokter/dsmr_parser',
     version='0.22',
-    packages=find_packages(),
+    packages=find_packages(exclude=('test', 'test.*')),
     install_requires=[
         'pyserial>=3,<4',
         'pyserial-asyncio<1',


### PR DESCRIPTION
Installing tests is generally not necessary or desirable in the first place, but particularly not in the global top level `test` package.

`test.*` is to catch possible subpackages added in the future.