### PR TITLE
Add Luxembourg equipment identifier

### DIFF
--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -29,6 +29,9 @@ def create_dsmr_protocol(dsmr_version, telegram_callback, loop=None):
     elif dsmr_version == '5B':
         specification = telegram_specifications.BELGIUM_FLUVIUS
         serial_settings = SERIAL_SETTINGS_V5
+    elif dsmr_version == "5L":
+        specification = telegram_specifications.LUXEMBOURG_SMARTY
+        serial_settings = SERIAL_SETTINGS_V5
     else:
         raise NotImplementedError("No telegram parser found for version: %s",
                                   dsmr_version)

--- a/dsmr_parser/obis_references.py
+++ b/dsmr_parser/obis_references.py
@@ -63,5 +63,6 @@ ELECTRICITY_DELIVERED_TARIFF_ALL = (
 
 # Alternate codes for foreign countries.
 BELGIUM_HOURLY_GAS_METER_READING = r'\d-\d:24\.2\.3.+?\r\n'  # Different code, same format.
+LUXEMBOURG_EQUIPMENT_IDENTIFIER = r'\d-\d:42\.0\.0.+?\r\n' # Logical device name
 LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL = r'\d-\d:1\.8\.0.+?\r\n'  # Total imported energy register (P+)
 LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL = r'\d-\d:2\.8\.0.+?\r\n'  # Total exported energy register (P-)

--- a/dsmr_parser/telegram_specifications.py
+++ b/dsmr_parser/telegram_specifications.py
@@ -152,6 +152,7 @@ BELGIUM_FLUVIUS['objects'].update({
 
 LUXEMBOURG_SMARTY = deepcopy(V5)
 LUXEMBOURG_SMARTY['objects'].update({
+    obis.LUXEMBOURG_EQUIPMENT_IDENTIFIER: CosemParser(ValueParser(str)),
     obis.LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL: CosemParser(ValueParser(Decimal)),
     obis.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL: CosemParser(ValueParser(Decimal)),
 })


### PR DESCRIPTION
The Smarty meter (Luxembourg) is using a different OBIS reference for equipment identifier compared to Dutch and Belgian meters (see https://smarty.creos.net/wp-content/uploads/P1PortSpecification.pdf).

Add the OBIS reference for Smarty and also enable to set `dsmr_version` to `5L` for Luxembourg meters.