### PR TITLE
add value and unit properties to ProfileGenericObject to make sure th…

### DIFF
--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -156,6 +156,16 @@ class ProfileGenericObject(DSMRObject):
         self._buffer_list = None
 
     @property
+    def value(self):
+        # value is added to make sure the telegram iterator does not break
+        return self.__str__()
+
+    @property
+    def unit(self):
+        # value is added to make sure all items have a unit so code that relies on that does not break
+        return None
+
+    @property
     def buffer_length(self):
         return self.values[0]['value']
 

--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -158,7 +158,7 @@ class ProfileGenericObject(DSMRObject):
     @property
     def value(self):
         # value is added to make sure the telegram iterator does not break
-        return self.__str__()
+        return self.values
 
     @property
     def unit(self):


### PR DESCRIPTION
Add value and unit properties to ProfileGenericObject to make sure that code like iterators that rely on that do not break.