### PR TITLE
Remove deprecated asyncio coroutine decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ also includes client implementation to directly read and parse smart meter data.
 Features
 --------
 
-DSMR Parser supports DSMR versions 2, 3, 4 and 5. It has been tested with Python 3.4, 3.5 and 3.6.
+DSMR Parser supports DSMR versions 2, 3, 4 and 5. It has been tested with Python 3.5, 3.6, 3.7. 3.8 and 3.9.
 
 
 Client module usage

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ also includes client implementation to directly read and parse smart meter data.
 Features
 --------
 
-DSMR Parser supports DSMR versions 2, 3, 4 and 5. It has been tested with Python 3.5, 3.6, 3.7. 3.8 and 3.9.
+DSMR Parser supports DSMR versions 2, 3, 4 and 5. It has been tested with Python 3.5, 3.6, 3.7, 3.8 and 3.9.
 
 
 Client module usage

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -136,7 +136,6 @@ class DSMRProtocol(asyncio.Protocol):
         else:
             self.telegram_callback(parsed_telegram)
 
-    @asyncio.coroutine
-    def wait_closed(self):
+    async def wait_closed(self):
         """Wait until connection is closed."""
-        yield from self._closed.wait()
+        await self._closed.wait()

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -68,8 +68,7 @@ class AsyncSerialReader(SerialReader):
 
     PORT_KEY = 'url'
 
-    @asyncio.coroutine
-    def read(self, queue):
+    async def read(self, queue):
         """
         Read complete DSMR telegram's from the serial interface and parse it
         into CosemObject's and MbusObject's.
@@ -81,12 +80,12 @@ class AsyncSerialReader(SerialReader):
         """
         # create Serial StreamReader
         conn = serial_asyncio.open_serial_connection(**self.serial_settings)
-        reader, _ = yield from conn
+        reader, _ = await conn
 
         while True:
             # Read line if available or give control back to loop until new
             # data has arrived.
-            data = yield from reader.readline()
+            data = await reader.readline()
             self.telegram_buffer.append(data.decode('ascii'))
 
             for telegram in self.telegram_buffer.get_all():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37,py38,py39
 
 [testenv]
 deps=


### PR DESCRIPTION
This PR removes the `@asyncio.coroutine` decorator and `yield from` occurrences from the codebase and replaces them with the Python 3.5 async/await syntax.

This PR causes Python 3.4 to be dropped for async serial use, adjusted the README for that.

Additionally, added Python 3.9 to tox.

closes #64