### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     description='Library to parse Dutch Smart Meter Requirements (DSMR)',
     author='Nigel Dokter and many others',
     author_email='nigel@nldr.net',
+    license='MIT',
     url='https://github.com/ndokter/dsmr_parser',
     version='0.28',
     packages=find_packages(exclude=('test', 'test.*')),


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.