### PR TITLE
Feature/python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cached PIP dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -44,4 +44,4 @@ jobs:
         run: tox
 
       - name: Code coverage upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'


### PR DESCRIPTION
- Run tests for Python 3.11 as well _(they seem to pass :confetti_ball: )_
- Bump versions of Actions used in CI
- No longer run Python 3.6 in CI as it is end-of-life _([for almost a year now)](https://devguide.python.org/versions/#python-release-cycle)_