### PR TITLE
add pylama back in + fix uniform style issues reported by pylama

### DIFF
--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -113,6 +113,7 @@ class MBusObject(DSMRObject):
         }
         return json.dumps(output)
 
+
 class MBusObjectPeak(DSMRObject):
 
     @property
@@ -132,7 +133,9 @@ class MBusObjectPeak(DSMRObject):
         return self.values[2]['unit']
 
     def __str__(self):
-        output = "{}\t[{}] at {} occurred {}".format(str(self.value), str(self.unit), str(self.datetime.astimezone().isoformat()), str(self.occurred.astimezone().isoformat()))
+        output = "{}\t[{}] at {} occurred {}"\
+            .format(str(self.value), str(self.unit), str(self.datetime.astimezone().isoformat()),
+                    str(self.occurred.astimezone().isoformat()))
         return output
 
     def to_json(self):

--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -244,10 +244,10 @@ class MaxDemandParser(DSMRObjectParser):
         objects = []
 
         count = int(values[0])
-        for i in range(1, count+1):
-            timestamp_month = ValueParser(timestamp).parse(values[i*3+1])
-            timestamp_occurred = ValueParser(timestamp).parse(values[i*3+1])
-            value = ValueParser(Decimal).parse(values[i*3+2])
+        for i in range(1, count + 1):
+            timestamp_month = ValueParser(timestamp).parse(values[i * 3 + 1])
+            timestamp_occurred = ValueParser(timestamp).parse(values[i * 3 + 1])
+            value = ValueParser(Decimal).parse(values[i * 3 + 2])
             objects.append(MBusObjectPeak([timestamp_month, timestamp_occurred, value]))
 
         return objects

--- a/test/test_parse_fluvius.py
+++ b/test/test_parse_fluvius.py
@@ -246,7 +246,6 @@ class TelegramParserFluviusTest(unittest.TestCase):
         assert isinstance(result[obis.BELGIUM_MBUS2_METER_READING1].value, Decimal)
         assert result[obis.BELGIUM_MBUS2_METER_READING1].value == Decimal('872.234')
 
-
     def test_checksum_valid(self):
         # No exception is raised.
         TelegramParser.validate_checksum(TELEGRAM_FLUVIUS_V171)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,25 @@
 deps=
   pytest
   pytest-cov
+  pylama
   pytest-asyncio
   pytest-mock
   dlms_cosem
 commands=
   py.test --cov=dsmr_parser test {posargs}
+  pylama dsmr_parser test
+
+[pylama:dsmr_parser/clients/__init__.py]
+ignore = W0611
+
+[pylama:dsmr_parser/parsers.py]
+ignore = W605
+
+[pylama:test/example_telegrams.py]
+ignore = E501
+
+[pylama:pylint]
+max_line_length = 120
+
+[pylama:pycodestyle]
+max_line_length = 120


### PR DESCRIPTION
Add pylama back in + fix uniform style issues reported by pylama.

Should work from python 3.7 onwards, as python 3.6 is no longer supported this shall not pose problems.