### PR TITLE
Fix parsing with invalid timestamps

### DIFF
--- a/dsmr_parser/value_types.py
+++ b/dsmr_parser/value_types.py
@@ -4,14 +4,23 @@ import pytz
 
 
 def timestamp(value):
-    naive_datetime = datetime.datetime.strptime(value[:-1], '%y%m%d%H%M%S')
+    try:
+        naive_datetime = datetime.datetime.strptime(value[:-1], '%y%m%d%H%M%S')
+    except ValueError:
+        return None
 
-    # TODO comment on this exception
+    # Timestamp has the following format:
+    # YYMMDDhhmmssX
+    # ASCII presentation of Time stamp with
+    # Year, Month, Day, Hour, Minute, Second,
+    # and an indication whether DST is active
+    # (X=S) or DST is not active (X=W)
     if len(value) == 13:
         is_dst = value[12] == 'S'  # assume format 160322150000W
     else:
         is_dst = False
 
+    # TODO : Use system timezone
     local_tz = pytz.timezone('Europe/Amsterdam')
     localized_datetime = local_tz.localize(naive_datetime, is_dst=is_dst)
 


### PR DESCRIPTION
Sometimes the timestamp in the DSMR message is invalid (when no data read read from the mbus meter?), and then parsing fails. Fixing this by handling the exception and returning None for invalid
timestamps. Fixes: #120