### PR TITLE
Adjust the naming of the MAX_POWER and MAX_CURRENT obis values

### DIFF
--- a/dsmr_parser/obis_references.py
+++ b/dsmr_parser/obis_references.py
@@ -43,6 +43,9 @@ INSTANTANEOUS_VOLTAGE_L3 = r'^\d-\d:72\.7\.0.+?\r\n'
 INSTANTANEOUS_CURRENT_L1 = r'^\d-\d:31\.7\.0.+?\r\n'
 INSTANTANEOUS_CURRENT_L2 = r'^\d-\d:51\.7\.0.+?\r\n'
 INSTANTANEOUS_CURRENT_L3 = r'^\d-\d:71\.7\.0.+?\r\n'
+FUSE_THRESHOLD_L1 = r'^\d-\d:31\.4\.0.+?\r\n'  # Applicable when current limitation is active
+FUSE_THRESHOLD_L2 = r'^\d-\d:51\.4\.0.+?\r\n'  # Applicable when current limitation is active
+FUSE_THRESHOLD_L3 = r'^\d-\d:71\.4\.0.+?\r\n'  # Applicable when current limitation is active
 TEXT_MESSAGE_CODE = r'^\d-\d:96\.13\.1.+?\r\n'
 TEXT_MESSAGE = r'^\d-\d:96\.13\.0.+?\r\n'
 DEVICE_TYPE = r'^\d-\d:24\.1\.0.+?\r\n'
@@ -89,7 +92,6 @@ BELGIUM_CURRENT_AVERAGE_DEMAND = r'^\d-\d:1\.4\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_MONTH = r'^\d-\d:1\.6\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_13_MONTHS = r'^\d-\d:98\.1\.0.+?\r\n'
 BELGIUM_MAX_POWER_PER_PHASE = r'^\d-\d:17\.0\.0.+?\r\n'  # Applicable when power limitation is active
-BELGIUM_MAX_CURRENT_PER_PHASE = r'^\d-\d:31\.4\.0.+?\r\n'  # Applicable when current limitation is active
 
 # Multiple 'slaves' can be linked to the main device.
 # Mostly MBUS1 = GAS METER with values on 24.2.3
@@ -142,5 +144,3 @@ EON_HU_INSTANTANEOUS_REACTIVE_POWER_Q1 = r'^\d-\d:5\.7\.0.+?\r\n'
 EON_HU_INSTANTANEOUS_REACTIVE_POWER_Q2 = r'^\d-\d:6\.7\.0.+?\r\n'
 EON_HU_INSTANTANEOUS_REACTIVE_POWER_Q3 = r'^\d-\d:7\.7\.0.+?\r\n'
 EON_HU_INSTANTANEOUS_REACTIVE_POWER_Q4 = r'^\d-\d:8\.7\.0.+?\r\n'
-EON_HU_MAX_POWER_ON_L2 = r'^\d-\d:51\.4\.0.+?\r\n'
-EON_HU_MAX_POWER_ON_L3 = r'^\d-\d:71\.4\.0.+?\r\n'

--- a/dsmr_parser/telegram_specifications.py
+++ b/dsmr_parser/telegram_specifications.py
@@ -630,9 +630,9 @@ BELGIUM_FLUVIUS = {
             'value_name': 'BELGIUM_MAX_POWER_PER_PHASE'
         },
         {
-            'obis_reference': obis.BELGIUM_MAX_CURRENT_PER_PHASE,
+            'obis_reference': obis.FUSE_THRESHOLD_L1,
             'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'BELGIUM_MAX_CURRENT_PER_PHASE'
+            'value_name': 'FUSE_THRESHOLD_L1'
         },
         {
             'obis_reference': obis.TEXT_MESSAGE,
@@ -1414,20 +1414,20 @@ EON_HUNGARY = {
             'value_name': 'INSTANTANEOUS_REACTIVE_POWER_Q4'
         },
         {
-            'obis_reference': obis.BELGIUM_MAX_CURRENT_PER_PHASE,
+            'obis_reference': obis.FUSE_THRESHOLD_L1,
             'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'MAX_POWER_ON_L1'
+            'value_name': 'FUSE_THRESHOLD_L1'
         },
         {
-            'obis_reference': obis.EON_HU_MAX_POWER_ON_L2,
+            'obis_reference': obis.FUSE_THRESHOLD_L2,
             'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'MAX_POWER_ON_L2'
+            'value_name': 'FUSE_THRESHOLD_L2'
             # Only with 3 phase meters
         },
         {
-            'obis_reference': obis.EON_HU_MAX_POWER_ON_L3,
+            'obis_reference': obis.FUSE_THRESHOLD_L3,
             'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'MAX_POWER_ON_L3'
+            'value_name': 'FUSE_THRESHOLD_L3'
             # Only with 3 phase meters
         },
         # I'm not sure which datas does this line containes. It should be the data of last minute of last month.

--- a/test/test_parse_fluvius.py
+++ b/test/test_parse_fluvius.py
@@ -216,11 +216,11 @@ class TelegramParserFluviusTest(unittest.TestCase):
         assert isinstance(result.BELGIUM_MAX_POWER_PER_PHASE.value, Decimal)
         assert result.BELGIUM_MAX_POWER_PER_PHASE.value == Decimal('999.9')
 
-        # BELGIUM_MAX_POWER_PER_PHASE (1-0:31.4.0)
-        assert isinstance(result.BELGIUM_MAX_CURRENT_PER_PHASE, CosemObject)
-        assert result.BELGIUM_MAX_CURRENT_PER_PHASE.unit == 'A'
-        assert isinstance(result.BELGIUM_MAX_CURRENT_PER_PHASE.value, Decimal)
-        assert result.BELGIUM_MAX_CURRENT_PER_PHASE.value == Decimal('999')
+        # FUSE_THRESHOLD_L1 (1-0:31.4.0)
+        assert isinstance(result.FUSE_THRESHOLD_L1, CosemObject)
+        assert result.FUSE_THRESHOLD_L1.unit == 'A'
+        assert isinstance(result.FUSE_THRESHOLD_L1.value, Decimal)
+        assert result.FUSE_THRESHOLD_L1.value == Decimal('999')
 
         # TEXT_MESSAGE (0-0:96.13.0)
         assert isinstance(result.TEXT_MESSAGE, CosemObject)

--- a/test/test_parse_v5_eon_hungary.py
+++ b/test/test_parse_v5_eon_hungary.py
@@ -263,23 +263,23 @@ class TelegramParserV5EONHUTest(unittest.TestCase):
         assert isinstance(telegram.INSTANTANEOUS_REACTIVE_POWER_Q4.value, Decimal)
         assert telegram.INSTANTANEOUS_REACTIVE_POWER_Q4.value == Decimal('00.000')
 
-        # EON_HU_MAX_POWER_ON_L1 (1-0:31.4.0)
-        assert isinstance(telegram.MAX_POWER_ON_L1, CosemObject)
-        assert telegram.MAX_POWER_ON_L1.unit == 'A'
-        assert isinstance(telegram.MAX_POWER_ON_L1.value, Decimal)
-        assert telegram.MAX_POWER_ON_L1.value == Decimal('200.00')
+        # FUSE_THRESHOLD_L1 (1-0:31.4.0)
+        assert isinstance(telegram.FUSE_THRESHOLD_L1, CosemObject)
+        assert telegram.FUSE_THRESHOLD_L1.unit == 'A'
+        assert isinstance(telegram.FUSE_THRESHOLD_L1.value, Decimal)
+        assert telegram.FUSE_THRESHOLD_L1.value == Decimal('200.00')
 
-        # EON_HU_MAX_POWER_ON_L2 (1-0:31.4.0)
-        assert isinstance(telegram.MAX_POWER_ON_L2, CosemObject)
-        assert telegram.MAX_POWER_ON_L2.unit == 'A'
-        assert isinstance(telegram.MAX_POWER_ON_L2.value, Decimal)
-        assert telegram.MAX_POWER_ON_L2.value == Decimal('200.00')
+        # FUSE_THRESHOLD_L2 (1-0:31.4.0)
+        assert isinstance(telegram.FUSE_THRESHOLD_L2, CosemObject)
+        assert telegram.FUSE_THRESHOLD_L2.unit == 'A'
+        assert isinstance(telegram.FUSE_THRESHOLD_L2.value, Decimal)
+        assert telegram.FUSE_THRESHOLD_L2.value == Decimal('200.00')
 
-        # EON_HU_MAX_POWER_ON_L3 (1-0:31.4.0)
-        assert isinstance(telegram.MAX_POWER_ON_L3, CosemObject)
-        assert telegram.MAX_POWER_ON_L3.unit == 'A'
-        assert isinstance(telegram.MAX_POWER_ON_L3.value, Decimal)
-        assert telegram.MAX_POWER_ON_L3.value == Decimal('200.00')
+        # FUSE_THRESHOLD_L3 (1-0:31.4.0)
+        assert isinstance(telegram.FUSE_THRESHOLD_L3, CosemObject)
+        assert telegram.FUSE_THRESHOLD_L3.unit == 'A'
+        assert isinstance(telegram.FUSE_THRESHOLD_L3.value, Decimal)
+        assert telegram.FUSE_THRESHOLD_L3.value == Decimal('200.00')
 
         # TEXT_MESSAGE (0-0:96.13.0)
         assert isinstance(telegram.TEXT_MESSAGE, CosemObject)


### PR DESCRIPTION
As BELGIUM_MAX_CURRENT_PER_PHASE was also used in the EON telegram. Better make it a global/non-country specific value and adjust it everywhere.
Still on the belgian meters it seems to only report a value for L1 even on a 3phase meter.