### PR TITLE
Mbus alt

### DIFF
--- a/dsmr_parser/obis_references.py
+++ b/dsmr_parser/obis_references.py
@@ -69,8 +69,25 @@ ACTUAL_TRESHOLD_ELECTRICITY = r'^\d-\d:17\.0\.0.+?\r\n'
 ACTUAL_SWITCH_POSITION = r'^\d-\d:96\.3\.10.+?\r\n'
 VALVE_POSITION_GAS = r'^\d-\d:24\.4\.0.+?\r\n'
 
+# Multiple 'slaves' can be linked to the main device.
+# The type is reported on 24.1.0
+# Specifications are in EN 13757-3
+# For example: Water mater = 7, Gas meter = 3
+# Identifier is on 96.1.0 (in NL for ex) or
+# on 96.1.1 (in BE for ex)
+# The values are reported on 24.2.1
+# With an exception in Belgium for the GAS meter
+# Be aware that for the gas volume, another OBIS-code is published
+# than the one listed in section 7 of DSMR P1.
+# This is due to the fact that in Belgium the not-temperature
+# corrected gas volume is used while in the Netherlands,
+# the temperature corrected gas volume is used.
+MBUS_DEVICE_TYPE = r'^\d-[1-9]:24\.1\.0.+?\r\n'
+MBUS_EQUIPMENT_IDENTIFIER = r'^\d-[1-9]:96\.1\.[01].+?\r\n'
+MBUS_VALVE_POSITION = r'^\d-[1-9]:24\.4\.0.+?\r\n'
+MBUS_METER_READING = r'^\d-[1-9]:24\.2\.[13].+?\r\n'
+
 # TODO 17.0.0
-# TODO 96.3.10
 
 ELECTRICITY_USED_TARIFF_ALL = (
     ELECTRICITY_USED_TARIFF_1,
@@ -91,36 +108,6 @@ BELGIUM_EQUIPMENT_IDENTIFIER = r'^\d-0:96\.1\.1.+?\r\n'
 BELGIUM_CURRENT_AVERAGE_DEMAND = r'^\d-\d:1\.4\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_MONTH = r'^\d-\d:1\.6\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_13_MONTHS = r'^\d-\d:98\.1\.0.+?\r\n'
-
-# Multiple 'slaves' can be linked to the main device.
-# Mostly MBUS1 = GAS METER with values on 24.2.3
-# While WATER METER reports it's values on 24.2.1
-# The GAS METER also reports its valve state on 24.4.0
-# Dev type for gas = 7 and water = 8
-BELGIUM_MBUS1_DEVICE_TYPE = r'^\d-1:24\.1\.0.+?\r\n'
-BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER = r'^\d-1:96\.1\.1.+?\r\n'
-BELGIUM_MBUS1_VALVE_POSITION = r'^\d-1:24\.4\.0.+?\r\n'
-BELGIUM_MBUS1_METER_READING1 = r'^\d-1:24\.2\.1.+?\r\n'
-BELGIUM_MBUS1_METER_READING2 = r'^\d-1:24\.2\.3.+?\r\n'
-
-BELGIUM_MBUS2_DEVICE_TYPE = r'^\d-2:24\.1\.0.+?\r\n'
-BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER = r'^\d-2:96\.1\.1.+?\r\n'
-BELGIUM_MBUS2_VALVE_POSITION = r'^\d-2:24\.4\.0.+?\r\n'
-BELGIUM_MBUS2_METER_READING1 = r'^\d-2:24\.2\.1.+?\r\n'
-BELGIUM_MBUS2_METER_READING2 = r'^\d-2:24\.2\.3.+?\r\n'
-
-BELGIUM_MBUS3_DEVICE_TYPE = r'^\d-3:24\.1\.0.+?\r\n'
-BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER = r'^\d-3:96\.1\.1.+?\r\n'
-BELGIUM_MBUS3_VALVE_POSITION = r'^\d-3:24\.4\.0.+?\r\n'
-BELGIUM_MBUS3_METER_READING1 = r'^\d-3:24\.2\.1.+?\r\n'
-BELGIUM_MBUS3_METER_READING2 = r'^\d-3:24\.2\.3.+?\r\n'
-
-BELGIUM_MBUS4_DEVICE_TYPE = r'^\d-4:24\.1\.0.+?\r\n'
-BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER = r'^\d-4:96\.1\.1.+?\r\n'
-BELGIUM_MBUS4_VALVE_POSITION = r'^\d-4:24\.4\.0.+?\r\n'
-BELGIUM_MBUS4_METER_READING1 = r'^\d-4:24\.2\.1.+?\r\n'
-BELGIUM_MBUS4_METER_READING2 = r'^\d-4:24\.2\.3.+?\r\n'
-
 
 LUXEMBOURG_EQUIPMENT_IDENTIFIER = r'^\d-\d:42\.0\.0.+?\r\n'  # Logical device name
 

--- a/dsmr_parser/objects.py
+++ b/dsmr_parser/objects.py
@@ -28,12 +28,12 @@ class Telegram(dict):
     def add(self, obis_reference, dsmr_object, obis_name):
         # Update name mapping used to get value by attribute. Example: telegram.P1_MESSAGE_HEADER
         setattr(self, obis_name, dsmr_object)
-        if obis_name not in self._item_names:  # TODO repeating obis references
-            self._item_names.append(obis_name)
 
         # TODO isinstance check: MaxDemandParser (BELGIUM_MAXIMUM_DEMAND_13_MONTHS) returns a list
         if isinstance(dsmr_object, DSMRObject) and dsmr_object.is_mbus_reading:
             self._add_mbus(obis_reference, dsmr_object, obis_name)
+        elif obis_name not in self._item_names:  # TODO repeating obis references
+            self._item_names.append(obis_name)
 
         # Fill dict which is only used for backwards compatibility
         if obis_reference not in self:

--- a/dsmr_parser/telegram_specifications.py
+++ b/dsmr_parser/telegram_specifications.py
@@ -431,11 +431,6 @@ V5 = {
             'value_name': 'TEXT_MESSAGE'
         },
         {
-            'obis_reference': obis.DEVICE_TYPE,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'DEVICE_TYPE'
-        },
-        {
             'obis_reference': obis.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
             'value_parser': CosemParser(ValueParser(Decimal)),
             'value_name': 'INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE'
@@ -466,17 +461,27 @@ V5 = {
             'value_name': 'INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE'
         },
         {
-            'obis_reference': obis.EQUIPMENT_IDENTIFIER_GAS,
-            'value_parser': CosemParser(ValueParser(str)),
-            'value_name': 'EQUIPMENT_IDENTIFIER_GAS'
+            'obis_reference': obis.MBUS_DEVICE_TYPE,
+            'value_parser': CosemParser(ValueParser(int)),
+            'value_name': 'MBUS_DEVICE_TYPE'
         },
         {
-            'obis_reference': obis.HOURLY_GAS_METER_READING,
-            'value_parser':  MBusParser(
+            'obis_reference': obis.MBUS_EQUIPMENT_IDENTIFIER,
+            'value_parser': CosemParser(ValueParser(str)),
+            'value_name': 'MBUS_EQUIPMENT_IDENTIFIER'
+        },
+        {
+            'obis_reference': obis.MBUS_VALVE_POSITION,
+            'value_parser': CosemParser(ValueParser(int)),
+            'value_name': 'MBUS_VALVE_POSITION'
+        },
+        {
+            'obis_reference': obis.MBUS_METER_READING,
+            'value_parser': MBusParser(
                 ValueParser(timestamp),
                 ValueParser(Decimal)
             ),
-            'value_name': 'HOURLY_GAS_METER_READING'
+            'value_name': 'MBUS_METER_READING'
         },
     ]
 }
@@ -625,11 +630,6 @@ BELGIUM_FLUVIUS = {
             'value_name': 'ACTUAL_TRESHOLD_ELECTRICITY'
         },
         {
-            'obis_reference': obis.ACTUAL_TRESHOLD_ELECTRICITY,
-            'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'ACTUAL_TRESHOLD_ELECTRICITY'
-        },
-        {
             'obis_reference': obis.FUSE_THRESHOLD_L1,
             'value_parser': CosemParser(ValueParser(Decimal)),
             'value_name': 'FUSE_THRESHOLD_L1'
@@ -640,128 +640,27 @@ BELGIUM_FLUVIUS = {
             'value_name': 'TEXT_MESSAGE'
         },
         {
-            'obis_reference': obis.BELGIUM_MBUS1_DEVICE_TYPE,
+            'obis_reference': obis.MBUS_DEVICE_TYPE,
             'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS1_DEVICE_TYPE'
+            'value_name': 'MBUS_DEVICE_TYPE'
         },
         {
-            'obis_reference': obis.BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            'obis_reference': obis.MBUS_EQUIPMENT_IDENTIFIER,
             'value_parser': CosemParser(ValueParser(str)),
-            'value_name': 'BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER'
+            'value_name': 'MBUS_EQUIPMENT_IDENTIFIER'
         },
         {
-            'obis_reference': obis.BELGIUM_MBUS1_VALVE_POSITION,
+            'obis_reference': obis.MBUS_VALVE_POSITION,
             'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS1_VALVE_POSITION'
+            'value_name': 'MBUS_VALVE_POSITION'
         },
         {
-            'obis_reference': obis.BELGIUM_MBUS1_METER_READING1,
+            'obis_reference': obis.MBUS_METER_READING,
             'value_parser': MBusParser(
                 ValueParser(timestamp),
                 ValueParser(Decimal)
             ),
-            'value_name': 'BELGIUM_MBUS1_METER_READING1'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS1_METER_READING2,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS1_METER_READING2'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS2_DEVICE_TYPE,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS2_DEVICE_TYPE'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
-            'value_parser': CosemParser(ValueParser(str)),
-            'value_name': 'BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS2_VALVE_POSITION,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS2_VALVE_POSITION'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS2_METER_READING1,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS2_METER_READING1'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS2_METER_READING2,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS2_METER_READING2'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS3_DEVICE_TYPE,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS3_DEVICE_TYPE'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
-            'value_parser': CosemParser(ValueParser(str)),
-            'value_name': 'BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS3_VALVE_POSITION,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS3_VALVE_POSITION'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS3_METER_READING1,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS3_METER_READING1'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS3_METER_READING2,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS3_METER_READING2'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS4_DEVICE_TYPE,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS4_DEVICE_TYPE'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
-            'value_parser': CosemParser(ValueParser(str)),
-            'value_name': 'BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS4_VALVE_POSITION,
-            'value_parser': CosemParser(ValueParser(int)),
-            'value_name': 'BELGIUM_MBUS4_VALVE_POSITION'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS4_METER_READING1,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS4_METER_READING1'
-        },
-        {
-            'obis_reference': obis.BELGIUM_MBUS4_METER_READING2,
-            'value_parser': MBusParser(
-                ValueParser(timestamp),
-                ValueParser(Decimal)
-            ),
-            'value_name': 'BELGIUM_MBUS4_METER_READING2'
+            'value_name': 'MBUS_METER_READING'
         },
     ]
 }

--- a/test/objects/test_mbusdevice.py
+++ b/test/objects/test_mbusdevice.py
@@ -15,59 +15,59 @@ class MbusDeviceTest(unittest.TestCase):
         device_type_parser = [
             object["value_parser"]
             for object in v5_objects
-            if object["obis_reference"] == obis_references.DEVICE_TYPE
+            if object["obis_reference"] == obis_references.MBUS_DEVICE_TYPE
         ][0]
         device_type = device_type_parser.parse('0-2:24.1.0(003)\r\n')
 
         equipment_parser = [
             object["value_parser"]
             for object in v5_objects
-            if object["obis_reference"] == obis_references.EQUIPMENT_IDENTIFIER_GAS
+            if object["obis_reference"] == obis_references.MBUS_EQUIPMENT_IDENTIFIER
         ][0]
         equipment = equipment_parser.parse('0-2:96.1.0(4730303339303031393336393930363139)\r\n')
 
         gas_reading_parser = [
             object["value_parser"]
             for object in v5_objects
-            if object["obis_reference"] == obis_references.HOURLY_GAS_METER_READING
+            if object["obis_reference"] == obis_references.MBUS_METER_READING
         ][0]
         gas_reading = gas_reading_parser.parse('0-2:24.2.1(200426223001S)(00246.138*m3)\r\n')
 
-        mbus_device = MbusDevice(channel_id=1)
-        mbus_device.add(obis_references.DEVICE_TYPE, device_type, "DEVICE_TYPE")
-        mbus_device.add(obis_references.EQUIPMENT_IDENTIFIER_GAS, equipment, "EQUIPMENT_IDENTIFIER_GAS")
-        mbus_device.add(obis_references.HOURLY_GAS_METER_READING, gas_reading, "HOURLY_GAS_METER_READING")
+        mbus_device = MbusDevice(channel_id=2)
+        mbus_device.add(obis_references.MBUS_DEVICE_TYPE, device_type, "MBUS_DEVICE_TYPE")
+        mbus_device.add(obis_references.MBUS_EQUIPMENT_IDENTIFIER, equipment, "MBUS_EQUIPMENT_IDENTIFIER")
+        mbus_device.add(obis_references.MBUS_METER_READING, gas_reading, "MBUS_METER_READING")
 
         self.mbus_device = mbus_device
 
     def test_attributes(self):
-        self.assertEqual(self.mbus_device.DEVICE_TYPE.value, 3)
-        self.assertEqual(self.mbus_device.DEVICE_TYPE.unit, None)
+        self.assertEqual(self.mbus_device.MBUS_DEVICE_TYPE.value, 3)
+        self.assertEqual(self.mbus_device.MBUS_DEVICE_TYPE.unit, None)
 
-        self.assertEqual(self.mbus_device.EQUIPMENT_IDENTIFIER_GAS.value,
+        self.assertEqual(self.mbus_device.MBUS_EQUIPMENT_IDENTIFIER.value,
                          '4730303339303031393336393930363139')
-        self.assertEqual(self.mbus_device.EQUIPMENT_IDENTIFIER_GAS.unit, None)
+        self.assertEqual(self.mbus_device.MBUS_EQUIPMENT_IDENTIFIER.unit, None)
 
-        self.assertEqual(self.mbus_device.HOURLY_GAS_METER_READING.value, Decimal('246.138'))
-        self.assertEqual(self.mbus_device.HOURLY_GAS_METER_READING.unit, 'm3')
+        self.assertEqual(self.mbus_device.MBUS_METER_READING.value, Decimal('246.138'))
+        self.assertEqual(self.mbus_device.MBUS_METER_READING.unit, 'm3')
 
     def test_to_json(self):
         self.assertEqual(
             json.loads(self.mbus_device.to_json()),
             {
-                'CHANNEL_ID': 1,
-                'DEVICE_TYPE': {'value': 3, 'unit': None},
-                'EQUIPMENT_IDENTIFIER_GAS': {'value': '4730303339303031393336393930363139', 'unit': None},
-                'HOURLY_GAS_METER_READING': {'datetime': '2020-04-26T20:30:01+00:00', 'value': 246.138, 'unit': 'm3'}}
+                'CHANNEL_ID': 2,
+                'MBUS_DEVICE_TYPE': {'value': 3, 'unit': None},
+                'MBUS_EQUIPMENT_IDENTIFIER': {'value': '4730303339303031393336393930363139', 'unit': None},
+                'MBUS_METER_READING': {'datetime': '2020-04-26T20:30:01+00:00', 'value': 246.138, 'unit': 'm3'}}
         )
 
     def test_str(self):
         self.assertEqual(
             str(self.mbus_device),
             (
-                'MBUS DEVICE (channel 1)\n'
-                '\tDEVICE_TYPE: 	 3	[None]\n'
-                '\tEQUIPMENT_IDENTIFIER_GAS: 	 4730303339303031393336393930363139	[None]\n'
-                '\tHOURLY_GAS_METER_READING: 	 246.138	[m3] at 2020-04-26T20:30:01+00:00\n'
+                'MBUS DEVICE (channel 2)\n'
+                '\tMBUS_DEVICE_TYPE: 	 3	[None]\n'
+                '\tMBUS_EQUIPMENT_IDENTIFIER: 	 4730303339303031393336393930363139	[None]\n'
+                '\tMBUS_METER_READING: 	 246.138	[m3] at 2020-04-26T20:30:01+00:00\n'
             )
         )

--- a/test/test_parse_fluvius.py
+++ b/test/test_parse_fluvius.py
@@ -228,47 +228,53 @@ class TelegramParserFluviusTest(unittest.TestCase):
         assert result.TEXT_MESSAGE.unit is None
         assert result.TEXT_MESSAGE.value is None
 
-        # BELGIUM_MBUS1_DEVICE_TYPE (0-1:24.1.0)
-        assert isinstance(result.BELGIUM_MBUS1_DEVICE_TYPE, CosemObject)
-        assert result.BELGIUM_MBUS1_DEVICE_TYPE.unit is None
-        assert isinstance(result.BELGIUM_MBUS1_DEVICE_TYPE.value, int)
-        assert result.BELGIUM_MBUS1_DEVICE_TYPE.value == 3
+        # MBUS DEVICE 1
+        mbus1 = result.get_mbus_device_by_channel(1)
 
-        # BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER (0-1:96.1.1)
-        assert isinstance(result.BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER, CosemObject)
-        assert result.BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER.unit is None
-        assert isinstance(result.BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER.value, str)
-        assert result.BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER.value == '37464C4F32313139303333373333'
+        # MBUS_DEVICE_TYPE (0-1:24.1.0)
+        assert isinstance(mbus1.MBUS_DEVICE_TYPE, CosemObject)
+        assert mbus1.MBUS_DEVICE_TYPE.unit is None
+        assert isinstance(mbus1.MBUS_DEVICE_TYPE.value, int)
+        assert mbus1.MBUS_DEVICE_TYPE.value == 3
 
-        # BELGIUM_MBUS1_VALVE_POSITION (0-1:24.4.0)
-        assert isinstance(result.BELGIUM_MBUS1_VALVE_POSITION, CosemObject)
-        assert result.BELGIUM_MBUS1_VALVE_POSITION.unit is None
-        assert isinstance(result.BELGIUM_MBUS1_VALVE_POSITION.value, int)
-        assert result.BELGIUM_MBUS1_VALVE_POSITION.value == 1
+        # MBUS_EQUIPMENT_IDENTIFIER (0-1:96.1.1)
+        assert isinstance(mbus1.MBUS_EQUIPMENT_IDENTIFIER, CosemObject)
+        assert mbus1.MBUS_EQUIPMENT_IDENTIFIER.unit is None
+        assert isinstance(mbus1.MBUS_EQUIPMENT_IDENTIFIER.value, str)
+        assert mbus1.MBUS_EQUIPMENT_IDENTIFIER.value == '37464C4F32313139303333373333'
 
-        # BELGIUM_MBUS1_METER_READING2 (0-1:24.2.3)
-        assert isinstance(result.BELGIUM_MBUS1_METER_READING2, MBusObject)
-        assert result.BELGIUM_MBUS1_METER_READING2.unit == 'm3'
-        assert isinstance(result.BELGIUM_MBUS1_METER_READING2.value, Decimal)
-        assert result.BELGIUM_MBUS1_METER_READING2.value == Decimal('112.384')
+        # MBUS_VALVE_POSITION (0-1:24.4.0)
+        assert isinstance(result.MBUS_VALVE_POSITION, CosemObject)
+        assert result.MBUS_VALVE_POSITION.unit is None
+        assert isinstance(result.MBUS_VALVE_POSITION.value, int)
+        assert result.MBUS_VALVE_POSITION.value == 1
 
-        # BELGIUM_MBUS2_DEVICE_TYPE (0-2:24.1.0)
-        assert isinstance(result.BELGIUM_MBUS2_DEVICE_TYPE, CosemObject)
-        assert result.BELGIUM_MBUS2_DEVICE_TYPE.unit is None
-        assert isinstance(result.BELGIUM_MBUS2_DEVICE_TYPE.value, int)
-        assert result.BELGIUM_MBUS2_DEVICE_TYPE.value == 7
+        # MBUS_METER_READING (0-1:24.2.3)
+        assert isinstance(mbus1.MBUS_METER_READING, MBusObject)
+        assert mbus1.MBUS_METER_READING.unit == 'm3'
+        assert isinstance(mbus1.MBUS_METER_READING.value, Decimal)
+        assert mbus1.MBUS_METER_READING.value == Decimal('112.384')
 
-        # BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER (0-2:96.1.1)
-        assert isinstance(result.BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER, CosemObject)
-        assert result.BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER.unit is None
-        assert isinstance(result.BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER.value, str)
-        assert result.BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER.value == '3853414731323334353637383930'
+        # MBUS DEVICE 2
+        mbus2 = result.get_mbus_device_by_channel(2)
 
-        # BELGIUM_MBUS2_METER_READING1 (0-1:24.2.1)
-        assert isinstance(result.BELGIUM_MBUS2_METER_READING1, MBusObject)
-        assert result.BELGIUM_MBUS2_METER_READING1.unit == 'm3'
-        assert isinstance(result.BELGIUM_MBUS2_METER_READING1.value, Decimal)
-        assert result.BELGIUM_MBUS2_METER_READING1.value == Decimal('872.234')
+        # MBUS_DEVICE_TYPE (0-2:24.1.0)
+        assert isinstance(mbus2.MBUS_DEVICE_TYPE, CosemObject)
+        assert mbus2.MBUS_DEVICE_TYPE.unit is None
+        assert isinstance(mbus2.MBUS_DEVICE_TYPE.value, int)
+        assert mbus2.MBUS_DEVICE_TYPE.value == 7
+
+        # MBUS_EQUIPMENT_IDENTIFIER (0-2:96.1.1)
+        assert isinstance(mbus2.MBUS_EQUIPMENT_IDENTIFIER, CosemObject)
+        assert mbus2.MBUS_EQUIPMENT_IDENTIFIER.unit is None
+        assert isinstance(mbus2.MBUS_EQUIPMENT_IDENTIFIER.value, str)
+        assert mbus2.MBUS_EQUIPMENT_IDENTIFIER.value == '3853414731323334353637383930'
+
+        # MBUS_METER_READING (0-1:24.2.1)
+        assert isinstance(mbus2.MBUS_METER_READING, MBusObject)
+        assert mbus2.MBUS_METER_READING.unit == 'm3'
+        assert isinstance(mbus2.MBUS_METER_READING.value, Decimal)
+        assert mbus2.MBUS_METER_READING.value == Decimal('872.234')
 
     def test_checksum_valid(self):
         # No exception is raised.
@@ -295,6 +301,8 @@ class TelegramParserFluviusTest(unittest.TestCase):
         parser = TelegramParser(telegram_specifications.BELGIUM_FLUVIUS)
         telegram = parser.parse(TELEGRAM_FLUVIUS_V171_ALT)
         json_data = json.loads(telegram.to_json())
+
+        self.maxDiff = None
 
         self.assertEqual(
             json_data,
@@ -338,26 +346,19 @@ class TelegramParserFluviusTest(unittest.TestCase):
              'ACTUAL_TRESHOLD_ELECTRICITY': {'value': 999.9, 'unit': 'kW'},
              'FUSE_THRESHOLD_L1': {'value': 999.0, 'unit': 'A'},
              'TEXT_MESSAGE': {'value': None, 'unit': None},
-             'BELGIUM_MBUS1_DEVICE_TYPE': {'value': 3, 'unit': None},
-             'MBUS_DEVICES': [{'BELGIUM_MBUS1_DEVICE_TYPE': {'value': 3, 'unit': None},
-                               'BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER': {'value': '37464C4F32313233303838303237',
+             'MBUS_DEVICES': [{'MBUS_DEVICE_TYPE': {'value': 3, 'unit': None},
+                               'MBUS_EQUIPMENT_IDENTIFIER': {'value': '37464C4F32313233303838303237',
                                                                       'unit': None},
-                               'BELGIUM_MBUS1_VALVE_POSITION': {'value': 1, 'unit': None},
-                               'BELGIUM_MBUS1_METER_READING2': {'datetime': '2023-11-02T11:10:02+00:00',
-                                                                'value': 92.287, 'unit': 'm3'},
+                               'MBUS_VALVE_POSITION': {'value': 1, 'unit': None},
+                               'MBUS_METER_READING': {'datetime': '2023-11-02T11:10:02+00:00',
+                                                                  'value': 92.287, 'unit': 'm3'},
                                'CHANNEL_ID': 1},
-                              {'BELGIUM_MBUS2_DEVICE_TYPE': {'value': 7, 'unit': None},
-                               'BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER': {'value': '3853455430303030393631313733',
+                              {'MBUS_DEVICE_TYPE': {'value': 7, 'unit': None},
+                               'MBUS_EQUIPMENT_IDENTIFIER': {'value': '3853455430303030393631313733',
                                                                       'unit': None},
-                               'BELGIUM_MBUS2_METER_READING1': {'datetime': '2023-11-02T11:15:32+00:00',
-                                                                'value': 8.579, 'unit': 'm3'},
-                               'CHANNEL_ID': 2}],
-             'BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER': {'value': '37464C4F32313233303838303237', 'unit': None},
-             'BELGIUM_MBUS1_VALVE_POSITION': {'value': 1, 'unit': None},
-             'BELGIUM_MBUS1_METER_READING2': {'datetime': '2023-11-02T11:10:02+00:00', 'value': 92.287, 'unit': 'm3'},
-             'BELGIUM_MBUS2_DEVICE_TYPE': {'value': 7, 'unit': None},
-             'BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER': {'value': '3853455430303030393631313733', 'unit': None},
-             'BELGIUM_MBUS2_METER_READING1': {'datetime': '2023-11-02T11:15:32+00:00', 'value': 8.579, 'unit': 'm3'}}
+                               'MBUS_METER_READING': {'datetime': '2023-11-02T11:15:32+00:00',
+                                                                  'value': 8.579, 'unit': 'm3'},
+                               'CHANNEL_ID': 2}]}
         )
 
     def test_to_str(self):
@@ -399,21 +400,14 @@ class TelegramParserFluviusTest(unittest.TestCase):
                 'ACTUAL_TRESHOLD_ELECTRICITY: 	 999.9	[kW]\n'
                 'FUSE_THRESHOLD_L1: 	 999	[A]\n'
                 'TEXT_MESSAGE: 	 None	[None]\n'
-                'BELGIUM_MBUS1_DEVICE_TYPE: 	 3	[None]\n'
                 'MBUS DEVICE (channel 1)\n'
-                '	BELGIUM_MBUS1_DEVICE_TYPE: 	 3	[None]\n'
-                '	BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: 	 37464C4F32313233303838303237	[None]\n'
-                '	BELGIUM_MBUS1_VALVE_POSITION: 	 1	[None]\n'
-                '	BELGIUM_MBUS1_METER_READING2: 	 92.287	[m3] at 2023-11-02T11:10:02+00:00\n'
+                '	MBUS_DEVICE_TYPE: 	 3	[None]\n'
+                '	MBUS_EQUIPMENT_IDENTIFIER: 	 37464C4F32313233303838303237	[None]\n'
+                '	MBUS_VALVE_POSITION: 	 1	[None]\n'
+                '	MBUS_METER_READING: 	 92.287	[m3] at 2023-11-02T11:10:02+00:00\n'
                 'MBUS DEVICE (channel 2)\n'
-                '	BELGIUM_MBUS2_DEVICE_TYPE: 	 7	[None]\n'
-                '	BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: 	 3853455430303030393631313733	[None]\n'
-                '	BELGIUM_MBUS2_METER_READING1: 	 8.579	[m3] at 2023-11-02T11:15:32+00:00\n'
-                'BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: 	 37464C4F32313233303838303237	[None]\n'
-                'BELGIUM_MBUS1_VALVE_POSITION: 	 1	[None]\n'
-                'BELGIUM_MBUS1_METER_READING2: 	 92.287	[m3] at 2023-11-02T11:10:02+00:00\n'
-                'BELGIUM_MBUS2_DEVICE_TYPE: 	 7	[None]\n'
-                'BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: 	 3853455430303030393631313733	[None]\n'
-                'BELGIUM_MBUS2_METER_READING1: 	 8.579	[m3] at 2023-11-02T11:15:32+00:00\n'
+                '	MBUS_DEVICE_TYPE: 	 7	[None]\n'
+                '	MBUS_EQUIPMENT_IDENTIFIER: 	 3853455430303030393631313733	[None]\n'
+                '	MBUS_METER_READING: 	 8.579	[m3] at 2023-11-02T11:15:32+00:00\n'
             )
         )

--- a/test/test_parse_v5.py
+++ b/test/test_parse_v5.py
@@ -172,12 +172,6 @@ class TelegramParserV5Test(unittest.TestCase):
         assert telegram.TEXT_MESSAGE.unit is None
         assert telegram.TEXT_MESSAGE.value is None
 
-        # DEVICE_TYPE (0-x:24.1.0)
-        assert isinstance(telegram.DEVICE_TYPE, CosemObject)
-        assert telegram.DEVICE_TYPE.unit is None
-        assert isinstance(telegram.DEVICE_TYPE.value, int)
-        assert telegram.DEVICE_TYPE.value == 3
-
         # INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE (1-0:21.7.0)
         assert isinstance(telegram.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE, CosemObject)
         assert telegram.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE.unit == 'kW'
@@ -215,27 +209,27 @@ class TelegramParserV5Test(unittest.TestCase):
         assert telegram.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE.value == Decimal('0')
 
         # There's only one Mbus device (gas meter) in this case. Alternatively
-        # use get_mbget_mbus_device_by_channel
+        # use get_mbus_device_by_channel
         gas_meter_devices = telegram.MBUS_DEVICES
         gas_meter_device = gas_meter_devices[0]
 
-        # EQUIPMENT_IDENTIFIER_GAS (0-x:96.1.0)
-        assert isinstance(gas_meter_device.DEVICE_TYPE, CosemObject)
-        assert gas_meter_device.DEVICE_TYPE.unit is None
-        assert isinstance(gas_meter_device.DEVICE_TYPE.value, int)
-        assert gas_meter_device.DEVICE_TYPE.value == 3
+        # MBUS_DEVICE_TYPE (0-1:96.1.0)
+        assert isinstance(gas_meter_device.MBUS_DEVICE_TYPE, CosemObject)
+        assert gas_meter_device.MBUS_DEVICE_TYPE.unit is None
+        assert isinstance(gas_meter_device.MBUS_DEVICE_TYPE.value, int)
+        assert gas_meter_device.MBUS_DEVICE_TYPE.value == 3
 
-        # EQUIPMENT_IDENTIFIER_GAS (0-x:96.1.0)
-        assert isinstance(gas_meter_device.EQUIPMENT_IDENTIFIER_GAS, CosemObject)
-        assert gas_meter_device.EQUIPMENT_IDENTIFIER_GAS.unit is None
-        assert isinstance(gas_meter_device.EQUIPMENT_IDENTIFIER_GAS.value, str)
-        assert gas_meter_device.EQUIPMENT_IDENTIFIER_GAS.value == '3232323241424344313233343536373839'
+        # MBUS_EQUIPMENT_IDENTIFIER (0-1:96.1.0)
+        assert isinstance(gas_meter_device.MBUS_EQUIPMENT_IDENTIFIER, CosemObject)
+        assert gas_meter_device.MBUS_EQUIPMENT_IDENTIFIER.unit is None
+        assert isinstance(gas_meter_device.MBUS_EQUIPMENT_IDENTIFIER.value, str)
+        assert gas_meter_device.MBUS_EQUIPMENT_IDENTIFIER.value == '3232323241424344313233343536373839'
 
-        # HOURLY_GAS_METER_READING (0-1:24.2.1)
-        assert isinstance(gas_meter_device.HOURLY_GAS_METER_READING, MBusObject)
-        assert gas_meter_device.HOURLY_GAS_METER_READING.unit == 'm3'
-        assert isinstance(telegram.HOURLY_GAS_METER_READING.value, Decimal)
-        assert gas_meter_device.HOURLY_GAS_METER_READING.value == Decimal('0.107')
+        # MBUS_METER_READING (0-1:24.2.1)
+        assert isinstance(gas_meter_device.MBUS_METER_READING, MBusObject)
+        assert gas_meter_device.MBUS_METER_READING.unit == 'm3'
+        assert isinstance(telegram.MBUS_METER_READING.value, Decimal)
+        assert gas_meter_device.MBUS_METER_READING.value == Decimal('0.107')
 
     def test_checksum_valid(self):
         # No exception is raised.
@@ -270,8 +264,11 @@ class TelegramParserV5Test(unittest.TestCase):
         parser = TelegramParser(telegram_specifications.V5)
         telegram = parser.parse(invalid_date_telegram)
 
-        # HOURLY_GAS_METER_READING (0-1:24.2.1)
-        assert isinstance(telegram.HOURLY_GAS_METER_READING, MBusObject)
-        assert telegram.HOURLY_GAS_METER_READING.unit is None
-        assert isinstance(telegram.HOURLY_GAS_METER_READING.value, Decimal)
-        assert telegram.HOURLY_GAS_METER_READING.value == Decimal('0.000')
+        # MBUS DEVICE 1
+        mbus1 = telegram.get_mbus_device_by_channel(1)
+
+        # MBUS_METER_READING (0-1:24.2.1)
+        assert isinstance(mbus1.MBUS_METER_READING, MBusObject)
+        assert mbus1.MBUS_METER_READING.unit is None
+        assert isinstance(mbus1.MBUS_METER_READING.value, Decimal)
+        assert mbus1.MBUS_METER_READING.value == Decimal('0.000')


### PR DESCRIPTION
Alternative implementation of #141

Instead of having a obis reference for each MBUS, only have 1 generic one.

This because at least the BE and the NL DSMR devices use MBUS.
Therefor we make the MBUS obis reference generic, and convert the V5
telegram to use MBUS values.

Also remove BELGIUM_MAX_POWER_PER_PHASE as this was a duplicate.

Finally set self.maxDiff = None to have a full test output on some
tests.

This new code can then be used in Home-Assistant to add MBUS devices.