### PR TITLE
Remove BELGIUM_MAX_POWER_PER_PHASE

### DIFF
--- a/dsmr_parser/obis_references.py
+++ b/dsmr_parser/obis_references.py
@@ -91,7 +91,6 @@ BELGIUM_EQUIPMENT_IDENTIFIER = r'^\d-0:96\.1\.1.+?\r\n'
 BELGIUM_CURRENT_AVERAGE_DEMAND = r'^\d-\d:1\.4\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_MONTH = r'^\d-\d:1\.6\.0.+?\r\n'
 BELGIUM_MAXIMUM_DEMAND_13_MONTHS = r'^\d-\d:98\.1\.0.+?\r\n'
-BELGIUM_MAX_POWER_PER_PHASE = r'^\d-\d:17\.0\.0.+?\r\n'  # Applicable when power limitation is active
 
 # Multiple 'slaves' can be linked to the main device.
 # Mostly MBUS1 = GAS METER with values on 24.2.3

--- a/dsmr_parser/telegram_specifications.py
+++ b/dsmr_parser/telegram_specifications.py
@@ -625,9 +625,9 @@ BELGIUM_FLUVIUS = {
             'value_name': 'ACTUAL_TRESHOLD_ELECTRICITY'
         },
         {
-            'obis_reference': obis.BELGIUM_MAX_POWER_PER_PHASE,
+            'obis_reference': obis.ACTUAL_TRESHOLD_ELECTRICITY,
             'value_parser': CosemParser(ValueParser(Decimal)),
-            'value_name': 'BELGIUM_MAX_POWER_PER_PHASE'
+            'value_name': 'ACTUAL_TRESHOLD_ELECTRICITY'
         },
         {
             'obis_reference': obis.FUSE_THRESHOLD_L1,
@@ -1233,7 +1233,7 @@ EON_HUNGARY = {
             # This seems to be wrong in documentation, it's not 0-0:96.50.68, but 0-0:96.3.10
         },
         {
-            'obis_reference': obis.BELGIUM_MAX_POWER_PER_PHASE,
+            'obis_reference': obis.ACTUAL_TRESHOLD_ELECTRICITY,
             'value_parser': CosemParser(ValueParser(Decimal)),
             'value_name': 'ACTUAL_TRESHOLD_ELECTRICITY'
         },

--- a/test/test_parse_fluvius.py
+++ b/test/test_parse_fluvius.py
@@ -211,11 +211,11 @@ class TelegramParserFluviusTest(unittest.TestCase):
         assert isinstance(result.ACTUAL_SWITCH_POSITION.value, int)
         assert result.ACTUAL_SWITCH_POSITION.value == 1
 
-        # BELGIUM_MAX_POWER_PER_PHASE (0-0:17.0.0)
-        assert isinstance(result.BELGIUM_MAX_POWER_PER_PHASE, CosemObject)
-        assert result.BELGIUM_MAX_POWER_PER_PHASE.unit == 'kW'
-        assert isinstance(result.BELGIUM_MAX_POWER_PER_PHASE.value, Decimal)
-        assert result.BELGIUM_MAX_POWER_PER_PHASE.value == Decimal('999.9')
+        # ACTUAL_TRESHOLD_ELECTRICITY (0-0:17.0.0)
+        assert isinstance(result.ACTUAL_TRESHOLD_ELECTRICITY, CosemObject)
+        assert result.ACTUAL_TRESHOLD_ELECTRICITY.unit == 'kW'
+        assert isinstance(result.ACTUAL_TRESHOLD_ELECTRICITY.value, Decimal)
+        assert result.ACTUAL_TRESHOLD_ELECTRICITY.value == Decimal('999.9')
 
         # FUSE_THRESHOLD_L1 (1-0:31.4.0)
         assert isinstance(result.FUSE_THRESHOLD_L1, CosemObject)
@@ -336,7 +336,6 @@ class TelegramParserFluviusTest(unittest.TestCase):
              'INSTANTANEOUS_CURRENT_L3': {'value': 0.52, 'unit': 'A'},
              'ACTUAL_SWITCH_POSITION': {'value': 1, 'unit': None},
              'ACTUAL_TRESHOLD_ELECTRICITY': {'value': 999.9, 'unit': 'kW'},
-             'BELGIUM_MAX_POWER_PER_PHASE': {'value': 999.9, 'unit': 'kW'},
              'FUSE_THRESHOLD_L1': {'value': 999.0, 'unit': 'A'},
              'TEXT_MESSAGE': {'value': None, 'unit': None},
              'BELGIUM_MBUS1_DEVICE_TYPE': {'value': 3, 'unit': None},
@@ -398,7 +397,6 @@ class TelegramParserFluviusTest(unittest.TestCase):
                 'INSTANTANEOUS_CURRENT_L3: 	 0.52	[A]\n'
                 'ACTUAL_SWITCH_POSITION: 	 1	[None]\n'
                 'ACTUAL_TRESHOLD_ELECTRICITY: 	 999.9	[kW]\n'
-                'BELGIUM_MAX_POWER_PER_PHASE: 	 999.9	[kW]\n'
                 'FUSE_THRESHOLD_L1: 	 999	[A]\n'
                 'TEXT_MESSAGE: 	 None	[None]\n'
                 'BELGIUM_MBUS1_DEVICE_TYPE: 	 3	[None]\n'


### PR DESCRIPTION
This commit removes BELGIUM_MAX_POWER_PER_PHASE and uses ACTUAL_TRESHOLD_ELECTRICITY as this has same regex. So useless to keep the BELIUM variant.