### PR TITLE
Copy head_parsers list on construct.

### DIFF
--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -335,7 +335,7 @@ class ProfileGenericParser(DSMRObjectParser):
     """
 
     def __init__(self, buffer_types, head_parsers, parsers_for_unidentified):
-        self.value_formats = head_parsers
+        self.value_formats = head_parsers.copy()
         self.buffer_types = buffer_types
         self.parsers_for_unidentified = parsers_for_unidentified
 


### PR DESCRIPTION
We need to create a copy of the head_parsers.
Otherwise the self.value_formats contains just a reference to head_parsers.
But the self.value_formats is modified in the _parse_values, causing invalid values in the head_parsers list.