### PR TITLE
Change checksum log level

### DIFF
--- a/dsmr_parser/clients/filereader.py
+++ b/dsmr_parser/clients/filereader.py
@@ -74,7 +74,7 @@ class FileReader(object):
                     try:
                         yield Telegram(telegram, self.telegram_parser, self.telegram_specification)
                     except InvalidChecksumError as e:
-                        logger.warning(str(e))
+                        logger.info(str(e))
                     except ParseError as e:
                         logger.error('Failed to parse telegram: %s', e)
 

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -150,7 +150,7 @@ class DSMRProtocol(asyncio.Protocol):
         try:
             parsed_telegram = self.telegram_parser.parse(telegram)
         except InvalidChecksumError as e:
-            self.log.warning(str(e))
+            self.log.info(str(e))
         except ParseError:
             self.log.exception("failed to parse telegram")
         else:

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -38,7 +38,7 @@ class SerialReader(object):
                     try:
                         yield self.telegram_parser.parse(telegram)
                     except InvalidChecksumError as e:
-                        logger.warning(str(e))
+                        logger.info(str(e))
                     except ParseError as e:
                         logger.error('Failed to parse telegram: %s', e)
 

--- a/dsmr_parser/clients/socket_.py
+++ b/dsmr_parser/clients/socket_.py
@@ -50,7 +50,7 @@ class SocketReader(object):
                     try:
                         yield self.telegram_parser.parse(telegram)
                     except InvalidChecksumError as e:
-                        logger.warning(str(e))
+                        logger.infp(str(e))
                     except ParseError as e:
                         logger.error('Failed to parse telegram: %s', e)
 

--- a/dsmr_parser/clients/socket_.py
+++ b/dsmr_parser/clients/socket_.py
@@ -50,7 +50,7 @@ class SocketReader(object):
                     try:
                         yield self.telegram_parser.parse(telegram)
                     except InvalidChecksumError as e:
-                        logger.infp(str(e))
+                        logger.info(str(e))
                     except ParseError as e:
                         logger.error('Failed to parse telegram: %s', e)
 


### PR DESCRIPTION
Checksum errors are currently mapped as a "warning" by the logger.

This is unwanted in most cases:

- Checksum errors tend to happen, sporadically. However, the end user cannot take any action to avoid these sporadic errors and subsequent telegrams are always error-free. The issue solves itself.
- Errors that are thrown as "warning" do appear in front-end systems, such as Home Assistant. This could cause questions and confusion with end-users that are worried by these warnings.
- Structural issues in communication require specific investigation by power users. These users are keen enough to level up the default error level from "warning" to, for example, "info"