### PR TITLE
Avoid loading timezone at runtime

### DIFF
--- a/dsmr_parser/value_types.py
+++ b/dsmr_parser/value_types.py
@@ -6,6 +6,7 @@ import pytz
 # Preload timezone to avoid loading in event loop later
 local_tz = pytz.timezone('Europe/Amsterdam')
 
+
 def timestamp(value):
     try:
         naive_datetime = datetime.datetime.strptime(value[:-1], '%y%m%d%H%M%S')

--- a/dsmr_parser/value_types.py
+++ b/dsmr_parser/value_types.py
@@ -2,6 +2,9 @@ import datetime
 
 import pytz
 
+# TODO : Use system timezone
+# Preload timezone to avoid loading in event loop later
+local_tz = pytz.timezone('Europe/Amsterdam')
 
 def timestamp(value):
     try:
@@ -20,8 +23,6 @@ def timestamp(value):
     else:
         is_dst = False
 
-    # TODO : Use system timezone
-    local_tz = pytz.timezone('Europe/Amsterdam')
     localized_datetime = local_tz.localize(naive_datetime, is_dst=is_dst)
 
     return localized_datetime.astimezone(pytz.utc)


### PR DESCRIPTION
Pytz will load timezone info from files in
a lazy fashion on first access. This triggers warnings in HA due to it blocking the event loop.

Pre-load the needed timezone info at module import instead, which will run in executor in HA.

Fixes #156 