### PR TITLE
Bump Github Actions to latest versions in favor of Node deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,15 +21,15 @@ jobs:
 
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cached PIP dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -44,4 +44,4 @@ jobs:
         run: tox
 
       - name: Code coverage upload
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4


### PR DESCRIPTION
Fixes warnings in CI: https://github.com/ndokter/dsmr_parser/actions/runs/9450071019

![Screenshot from 2024-06-14 20-44-04](https://github.com/ndokter/dsmr_parser/assets/16581744/3c578ecc-3f12-4fa8-85fb-676faf9adfb0)

- https://github.com/actions/checkout/releases
- https://github.com/actions/setup-python/releases
- https://github.com/actions/cache/releases
- https://github.com/codecov/codecov-action/releases
