### PR TITLE
Don't thow an error when string can't be decoded to ascii

### DIFF
--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -35,7 +35,7 @@ class SerialReader(object):
                 try:
                     decoded_data = data.decode('ascii')
                 except:
-                    pass
+                    logger.warning('Failed to decode telegram data: %s', data)
                 else:
                     self.telegram_buffer.append(decoded_data)
 
@@ -59,7 +59,7 @@ class SerialReader(object):
                 try:
                     decoded_data = data.decode('ascii')
                 except:
-                    pass
+                    logger.warning('Failed to decode telegram data: %s', data)
                 else:
                     self.telegram_buffer.append(decoded_data)
 
@@ -98,7 +98,7 @@ class AsyncSerialReader(SerialReader):
             try:
                 decoded_data = data.decode('ascii')
             except:
-                pass
+                logger.warning('Failed to decode telegram data: %s', data)
             else:
                 self.telegram_buffer.append(decoded_data)
 
@@ -134,7 +134,7 @@ class AsyncSerialReader(SerialReader):
             try:
                 decoded_data = data.decode('ascii')
             except:
-                pass
+                logger.warning('Failed to decode telegram data: %s', data)
             else:
                 self.telegram_buffer.append(decoded_data)
 

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -1,5 +1,4 @@
 import logging
-from importlib.metadata import pass_none
 
 import serial
 import serial_asyncio_fast

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -35,7 +35,7 @@ class SerialReader(object):
                 try:
                     decoded_data = data.decode('ascii')
                 except:
-                    yield None
+                    pass
                 else:
                     self.telegram_buffer.append(decoded_data)
 
@@ -59,7 +59,7 @@ class SerialReader(object):
                 try:
                     decoded_data = data.decode('ascii')
                 except:
-                    yield None
+                    pass
                 else:
                     self.telegram_buffer.append(decoded_data)
 
@@ -98,7 +98,7 @@ class AsyncSerialReader(SerialReader):
             try:
                 decoded_data = data.decode('ascii')
             except:
-                yield None
+                pass
             else:
                 self.telegram_buffer.append(decoded_data)
 
@@ -134,7 +134,7 @@ class AsyncSerialReader(SerialReader):
             try:
                 decoded_data = data.decode('ascii')
             except:
-                yield None
+                pass
             else:
                 self.telegram_buffer.append(decoded_data)
 


### PR DESCRIPTION
Possible solution for Issue #80. Instead of throwing an exception when input from serial can't be parsed, it passes the current step while the loop keeps going. This will mean one 'row' is missing from the telegram. The user should keep this in mind and not expect every telegram to be formed the same way.

Another option is to yield None, which I tried first. On second thought, it is not that helpful because there is nothing to return (though we could give the 'raw' bytestring, but that would complicate things for the user as well.