### PR TITLE
Migrate from pyserial/pyserial-asyncio-fast to serialx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -4,7 +4,7 @@ from functools import partial
 import asyncio
 import logging
 
-from serial_asyncio_fast import create_serial_connection
+from serialx import create_serial_connection
 
 from dsmr_parser import telegram_specifications
 from dsmr_parser.clients.telegram_buffer import TelegramBuffer

--- a/dsmr_parser/clients/rfxtrx_protocol.py
+++ b/dsmr_parser/clients/rfxtrx_protocol.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from serial_asyncio_fast import create_serial_connection
+from serialx import create_serial_connection
 from .protocol import DSMRProtocol, _create_dsmr_protocol
 
 

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -1,7 +1,6 @@
 import logging
 
-import serial
-import serial_asyncio_fast
+import serialx
 
 from dsmr_parser.clients.telegram_buffer import TelegramBuffer
 from dsmr_parser.exceptions import ParseError, InvalidChecksumError
@@ -12,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class SerialReader(object):
-    PORT_KEY = 'port'
+    PORT_KEY = 'url'
 
     def __init__(self, device, serial_settings, telegram_specification):
         self.serial_settings = serial_settings
@@ -29,9 +28,9 @@ class SerialReader(object):
 
         :rtype: generator
         """
-        with serial.Serial(**self.serial_settings) as serial_handle:
+        with serialx.serial_for_url(**self.serial_settings) as serial_handle:
             while True:
-                data = serial_handle.read(max(1, min(1024, serial_handle.in_waiting)))
+                data = serial_handle.read(max(1, min(1024, serial_handle.num_unread_bytes())))
                 try:
                     decoded_data = data.decode('ascii')
                 except Exception:
@@ -53,7 +52,7 @@ class SerialReader(object):
 
         :rtype: generator
         """
-        with serial.Serial(**self.serial_settings) as serial_handle:
+        with serialx.serial_for_url(**self.serial_settings) as serial_handle:
             while True:
                 data = serial_handle.readline()
                 try:
@@ -73,7 +72,7 @@ class SerialReader(object):
 
 
 class AsyncSerialReader(SerialReader):
-    """Serial reader using asyncio pyserial."""
+    """Serial reader using asyncio serialx."""
 
     PORT_KEY = 'url'
 
@@ -88,7 +87,7 @@ class AsyncSerialReader(SerialReader):
         :rtype: None
         """
         # create Serial StreamReader
-        conn = serial_asyncio_fast.open_serial_connection(**self.serial_settings)
+        conn = serialx.open_serial_connection(**self.serial_settings)
         reader, _ = await conn
 
         while True:
@@ -123,7 +122,7 @@ class AsyncSerialReader(SerialReader):
         """
 
         # create Serial StreamReader
-        conn = serial_asyncio_fast.open_serial_connection(**self.serial_settings)
+        conn = serialx.open_serial_connection(**self.serial_settings)
         reader, _ = await conn
 
         while True:

--- a/dsmr_parser/clients/settings.py
+++ b/dsmr_parser/clients/settings.py
@@ -1,11 +1,11 @@
-import serial
+import serialx
 
 
 SERIAL_SETTINGS_V2_2 = {
     'baudrate': 9600,
-    'bytesize': serial.SEVENBITS,
-    'parity': serial.PARITY_EVEN,
-    'stopbits': serial.STOPBITS_ONE,
+    'bytesize': serialx.SEVENBITS,
+    'parity': serialx.PARITY_EVEN,
+    'stopbits': serialx.STOPBITS_ONE,
     'xonxoff': 0,
     'rtscts': 0,
     'timeout': 20
@@ -13,9 +13,9 @@ SERIAL_SETTINGS_V2_2 = {
 
 SERIAL_SETTINGS_V4 = {
     'baudrate': 115200,
-    'bytesize': serial.SEVENBITS,
-    'parity': serial.PARITY_EVEN,
-    'stopbits': serial.STOPBITS_ONE,
+    'bytesize': serialx.SEVENBITS,
+    'parity': serialx.PARITY_EVEN,
+    'stopbits': serialx.STOPBITS_ONE,
     'xonxoff': 0,
     'rtscts': 0,
     'timeout': 20
@@ -23,9 +23,9 @@ SERIAL_SETTINGS_V4 = {
 
 SERIAL_SETTINGS_V5 = {
     'baudrate': 115200,
-    'bytesize': serial.EIGHTBITS,
-    'parity': serial.PARITY_NONE,
-    'stopbits': serial.STOPBITS_ONE,
+    'bytesize': serialx.EIGHTBITS,
+    'parity': serialx.PARITY_NONE,
+    'stopbits': serialx.STOPBITS_ONE,
     'xonxoff': 0,
     'rtscts': 0,
     'timeout': 20

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version='1.6.0',
     packages=find_packages(exclude=('test', 'test.*')),
     install_requires=[
-        'serialx==1.8.*',
+        'serialx>=1.8,<2',
         'Tailer==0.4.1',
         'dlms_cosem==21.3.2'
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     entry_points={
         'console_scripts': ['dsmr_console=dsmr_parser.__main__:console']
     },
+    python_requires='>=3.10',
     classifiers=[
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version='1.6.0',
     packages=find_packages(exclude=('test', 'test.*')),
     install_requires=[
-        'serialx',
+        'serialx==1.8.*',
         'Tailer==0.4.1',
         'dlms_cosem==21.3.2'
     ],

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setup(
     version='1.6.0',
     packages=find_packages(exclude=('test', 'test.*')),
     install_requires=[
-        'pyserial>=3,<4',
-        'pyserial-asyncio-fast>=0.11',
+        'serialx',
         'Tailer==0.4.1',
         'dlms_cosem==21.3.2'
     ],


### PR DESCRIPTION
Replace pyserial and pyserial-asyncio-fast dependencies with the unified serialx package. Switch sync construction to serialx.serial_for_url(), update in_waiting to num_unread_bytes(), and route async helpers through serialx.

Fixes #179 