### PR TITLE
CI: Update Actions versions to Node 24 LTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build container image
         run: |
@@ -41,6 +41,6 @@ jobs:
           docker rm test-container
 
       - name: Code coverage upload
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.xml


### PR DESCRIPTION
[Node 20 is EOL](https://endoflife.date/nodejs), bump Actions to use at least Node 24LTS, good for almost another 2 years.

I cannot test the 'release' CI workflow, but I have no doubt it will still work, as your setup does not have any custom scripts in it.