### PR TITLE
Binary framing for encrypted telegrams over the serial/network readers

### DIFF
--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -7,8 +7,8 @@ import logging
 from serialx import create_serial_connection
 
 from dsmr_parser import telegram_specifications
-from dsmr_parser.clients.telegram_buffer import TelegramBuffer
-from dsmr_parser.exceptions import ParseError, InvalidChecksumError
+from dsmr_parser.clients.telegram_buffer import TelegramBuffer, EncryptedTelegramBuffer
+from dsmr_parser.exceptions import ParseError, InvalidChecksumError, DecryptionError
 from dsmr_parser.parsers import TelegramParser
 from dsmr_parser.clients.settings import SERIAL_SETTINGS_V2_2, \
     SERIAL_SETTINGS_V4, SERIAL_SETTINGS_V5
@@ -114,14 +114,21 @@ class DSMRProtocol(asyncio.Protocol):
         self.telegram_parser = telegram_parser
         # callback to call on complete telegram
         self.telegram_callback = telegram_callback
+        # keys used to decrypt encrypted (general-global-cipher) telegrams
+        self._encryption_key = encryption_key
+        self._authentication_key = authentication_key
+        self._encrypted = bool(
+            telegram_parser.telegram_specification.get("general_global_cipher"))
+        # set when a telegram could not be decrypted; a fatal, unrecoverable
+        # condition (wrong key) that tears down the connection
+        self.decryption_error: DecryptionError | None = None
         # buffer to keep incomplete incoming data
-        self.telegram_buffer = TelegramBuffer()
+        self.telegram_buffer = \
+            EncryptedTelegramBuffer() if self._encrypted else TelegramBuffer()
         # keep a lock until the connection is closed
         self._closed = asyncio.Event()
         self._keep_alive_interval = keep_alive_interval
         self._active = True
-        self._encryption_key = encryption_key
-        self._authentication_key = authentication_key
 
     def connection_made(self, transport):
         """Just logging for now."""
@@ -133,10 +140,17 @@ class DSMRProtocol(asyncio.Protocol):
 
     def data_received(self, data):
         """Add incoming data to buffer."""
+        self._active = True
+
+        if self._encrypted:
+            # Encrypted telegrams are binary DLMS frames; buffer the raw bytes.
+            self.telegram_buffer.append(data)
+            for telegram in self.telegram_buffer.get_all():
+                self.handle_telegram(telegram)
+            return
 
         # accept latin-1 (8-bit) on the line, to allow for non-ascii transport or padding
         data = data.decode("latin1")
-        self._active = True
         self.log.debug('received data: %s', data)
         self.telegram_buffer.append(data)
 
@@ -174,6 +188,14 @@ class DSMRProtocol(asyncio.Protocol):
                 encryption_key=self._encryption_key,
                 authentication_key=self._authentication_key,
             )
+        except DecryptionError as e:
+            # Unrecoverable: with a configured key every telegram will fail the
+            # same way. Record it and tear down the connection instead of
+            # spinning on broken telegrams.
+            self.log.error("Failed to decrypt telegram, check the keys: %s", e)
+            self.decryption_error = e
+            if self.transport:
+                self.transport.close()
         except InvalidChecksumError as e:
             self.log.info(str(e))
         except ParseError:

--- a/dsmr_parser/clients/serial_.py
+++ b/dsmr_parser/clients/serial_.py
@@ -2,7 +2,7 @@ import logging
 
 import serialx
 
-from dsmr_parser.clients.telegram_buffer import TelegramBuffer
+from dsmr_parser.clients.telegram_buffer import TelegramBuffer, EncryptedTelegramBuffer
 from dsmr_parser.exceptions import ParseError, InvalidChecksumError
 from dsmr_parser.parsers import TelegramParser
 
@@ -13,13 +13,32 @@ logger = logging.getLogger(__name__)
 class SerialReader(object):
     PORT_KEY = 'url'
 
-    def __init__(self, device, serial_settings, telegram_specification):
+    def __init__(self, device, serial_settings, telegram_specification,
+                 encryption_key="", authentication_key=""):
         self.serial_settings = serial_settings
         self.serial_settings[self.PORT_KEY] = device
 
         self.telegram_parser = TelegramParser(telegram_specification)
-        self.telegram_buffer = TelegramBuffer()
         self.telegram_specification = telegram_specification
+        self._encryption_key = encryption_key
+        self._authentication_key = authentication_key
+        self._encrypted = bool(telegram_specification.get("general_global_cipher"))
+        self.telegram_buffer = \
+            EncryptedTelegramBuffer() if self._encrypted else TelegramBuffer()
+
+    def _buffer_incoming(self, data):
+        """
+        Append raw transport bytes to the buffer and return the complete
+        telegrams ready to be parsed. Encrypted telegrams are binary DLMS
+        frames and must not be decoded; plain telegrams are ascii.
+        :param bytes data:
+        :rtype generator:
+        """
+        if self._encrypted:
+            self.telegram_buffer.append(data)
+        else:
+            self.telegram_buffer.append(data.decode('ascii'))
+        return self.telegram_buffer.get_all()
 
     def read(self):
         """
@@ -32,19 +51,19 @@ class SerialReader(object):
             while True:
                 data = serial_handle.read(max(1, min(1024, serial_handle.num_unread_bytes())))
                 try:
-                    decoded_data = data.decode('ascii')
+                    telegrams = self._buffer_incoming(data)
                 except Exception:
                     logger.warning('Failed to decode telegram data: %s', data)
-                else:
-                    self.telegram_buffer.append(decoded_data)
+                    continue
 
-                    for telegram in self.telegram_buffer.get_all():
-                        try:
-                            yield self.telegram_parser.parse(telegram)
-                        except InvalidChecksumError as e:
-                            logger.info(str(e))
-                        except ParseError as e:
-                            logger.error('Failed to parse telegram: %s', e)
+                for telegram in telegrams:
+                    try:
+                        yield self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
+                    except InvalidChecksumError as e:
+                        logger.info(str(e))
+                    except ParseError as e:
+                        logger.error('Failed to parse telegram: %s', e)
 
     def read_as_object(self):
         """
@@ -56,19 +75,19 @@ class SerialReader(object):
             while True:
                 data = serial_handle.readline()
                 try:
-                    decoded_data = data.decode('ascii')
+                    telegrams = self._buffer_incoming(data)
                 except Exception:
                     logger.warning('Failed to decode telegram data: %s', data)
-                else:
-                    self.telegram_buffer.append(decoded_data)
+                    continue
 
-                    for telegram in self.telegram_buffer.get_all():
-                        try:
-                            yield self.telegram_parser.parse(telegram)
-                        except InvalidChecksumError as e:
-                            logger.warning(str(e))
-                        except ParseError as e:
-                            logger.error('Failed to parse telegram: %s', e)
+                for telegram in telegrams:
+                    try:
+                        yield self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
+                    except InvalidChecksumError as e:
+                        logger.warning(str(e))
+                    except ParseError as e:
+                        logger.error('Failed to parse telegram: %s', e)
 
 
 class AsyncSerialReader(SerialReader):
@@ -95,20 +114,20 @@ class AsyncSerialReader(SerialReader):
             # data has arrived.
             data = await reader.readline()
             try:
-                decoded_data = data.decode('ascii')
+                telegrams = self._buffer_incoming(data)
             except Exception:
                 logger.warning('Failed to decode telegram data: %s', data)
-            else:
-                self.telegram_buffer.append(decoded_data)
+                continue
 
-                for telegram in self.telegram_buffer.get_all():
-                    try:
-                        # Push new parsed telegram onto queue.
-                        queue.put_nowait(
-                            self.telegram_parser.parse(telegram)
-                        )
-                    except ParseError as e:
-                        logger.warning('Failed to parse telegram: %s', e)
+            for telegram in telegrams:
+                try:
+                    # Push new parsed telegram onto queue.
+                    queue.put_nowait(
+                        self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
+                    )
+                except ParseError as e:
+                    logger.warning('Failed to parse telegram: %s', e)
 
     async def read_as_object(self, queue):
         """
@@ -131,18 +150,18 @@ class AsyncSerialReader(SerialReader):
             # data has arrived.
             data = await reader.readline()
             try:
-                decoded_data = data.decode('ascii')
+                telegrams = self._buffer_incoming(data)
             except Exception:
                 logger.warning('Failed to decode telegram data: %s', data)
-            else:
-                self.telegram_buffer.append(decoded_data)
+                continue
 
-                for telegram in self.telegram_buffer.get_all():
-                    try:
-                        queue.put_nowait(
-                            self.telegram_parser.parse(telegram)
-                        )
-                    except InvalidChecksumError as e:
-                        logger.warning(str(e))
-                    except ParseError as e:
-                        logger.error('Failed to parse telegram: %s', e)
+            for telegram in telegrams:
+                try:
+                    queue.put_nowait(
+                        self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
+                    )
+                except InvalidChecksumError as e:
+                    logger.warning(str(e))
+                except ParseError as e:
+                    logger.error('Failed to parse telegram: %s', e)

--- a/dsmr_parser/clients/socket_.py
+++ b/dsmr_parser/clients/socket_.py
@@ -1,7 +1,7 @@
 import logging
 import socket
 
-from dsmr_parser.clients.telegram_buffer import TelegramBuffer
+from dsmr_parser.clients.telegram_buffer import TelegramBuffer, EncryptedTelegramBuffer
 from dsmr_parser.exceptions import ParseError, InvalidChecksumError
 from dsmr_parser.parsers import TelegramParser
 
@@ -13,13 +13,39 @@ class SocketReader(object):
 
     BUFFER_SIZE = 256
 
-    def __init__(self, host, port, telegram_specification):
+    def __init__(self, host, port, telegram_specification,
+                 encryption_key="", authentication_key=""):
         self.host = host
         self.port = port
 
         self.telegram_parser = TelegramParser(telegram_specification)
-        self.telegram_buffer = TelegramBuffer()
         self.telegram_specification = telegram_specification
+        self._encryption_key = encryption_key
+        self._authentication_key = authentication_key
+        self._encrypted = bool(telegram_specification.get("general_global_cipher"))
+        self.telegram_buffer = \
+            EncryptedTelegramBuffer() if self._encrypted else TelegramBuffer()
+
+    def _buffer_incoming(self, data):
+        """
+        Append raw bytes received from the socket to the buffer and return the
+        complete telegrams ready to be parsed. Encrypted telegrams are binary
+        DLMS frames and are buffered as raw bytes; plain telegrams are split
+        into ascii lines (tolerating garbage as before).
+        :param bytes data:
+        :rtype generator:
+        """
+        if self._encrypted:
+            self.telegram_buffer.append(data)
+        else:
+            for line in data.splitlines(keepends=True):
+                try:
+                    self.telegram_buffer.append(line.decode('ascii'))
+                except UnicodeDecodeError:
+                    # Some garbage came through the channel
+                    # E.g.: Happens at EON_HUNGARY, but only once at the start.
+                    logger.error('Failed to parse telegram due to unicode decode error')
+        return self.telegram_buffer.get_all()
 
     def read(self):
         """
@@ -28,41 +54,25 @@ class SocketReader(object):
 
         :rtype: generator
         """
-        buffer = b""
-
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as socket_handle:
             socket_handle.settimeout(60)
             socket_handle.connect((self.host, self.port))
 
             while True:
                 try:
-                    buffer += socket_handle.recv(self.BUFFER_SIZE)
+                    data = socket_handle.recv(self.BUFFER_SIZE)
                 except socket.timeout:
                     logger.error("Socket timeout occurred, exiting")
                     break
 
-                lines = buffer.splitlines(keepends=True)
-
-                if len(lines) == 0:
-                    continue
-
-                for data in lines:
+                for telegram in self._buffer_incoming(data):
                     try:
-                        self.telegram_buffer.append(data.decode('ascii'))
-                    except UnicodeDecodeError:
-                        # Some garbage came through the channel
-                        # E.g.: Happens at EON_HUNGARY, but only once at the start of the socket.
-                        logger.error('Failed to parse telegram due to unicode decode error')
-
-                for telegram in self.telegram_buffer.get_all():
-                    try:
-                        yield self.telegram_parser.parse(telegram)
+                        yield self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
                     except InvalidChecksumError as e:
                         logger.info(str(e))
                     except ParseError as e:
                         logger.error('Failed to parse telegram: %s', e)
-
-                buffer = b""
 
     def read_as_object(self):
         """
@@ -70,29 +80,18 @@ class SocketReader(object):
 
         :rtype: generator
         """
-        buffer = b""
-
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as socket_handle:
 
             socket_handle.connect((self.host, self.port))
 
             while True:
-                buffer += socket_handle.recv(self.BUFFER_SIZE)
+                data = socket_handle.recv(self.BUFFER_SIZE)
 
-                lines = buffer.splitlines(keepends=True)
-
-                if len(lines) == 0:
-                    continue
-
-                for data in lines:
-                    self.telegram_buffer.append(data.decode('ascii'))
-
-                    for telegram in self.telegram_buffer.get_all():
-                        try:
-                            yield self.telegram_parser.parse(telegram)
-                        except InvalidChecksumError as e:
-                            logger.warning(str(e))
-                        except ParseError as e:
-                            logger.error('Failed to parse telegram: %s', e)
-
-                buffer = b""
+                for telegram in self._buffer_incoming(data):
+                    try:
+                        yield self.telegram_parser.parse(
+                            telegram, self._encryption_key, self._authentication_key)
+                    except InvalidChecksumError as e:
+                        logger.warning(str(e))
+                    except ParseError as e:
+                        logger.error('Failed to parse telegram: %s', e)

--- a/dsmr_parser/clients/telegram_buffer.py
+++ b/dsmr_parser/clients/telegram_buffer.py
@@ -45,3 +45,79 @@ class TelegramBuffer(object):
         index = self._buffer.index(telegram) + len(telegram)
 
         self._buffer = self._buffer[index:]
+
+
+class EncryptedTelegramBuffer(object):
+    """
+    Used as a buffer for a stream of encrypted (DLMS general-global-cipher)
+    telegram data.
+
+    Encrypted telegrams (e.g. Luxembourg Smarty, Austrian Sagemcom) are not
+    delimited by the '/...!XXXX' framing of plain telegrams. They are binary
+    DLMS APDUs that start with the general-global-cipher tag (0xDB) and carry
+    their own length, so they are framed by parsing that length rather than by
+    a regex. Complete frames are yielded as hex strings, which is the format
+    expected by ``TelegramParser.parse``.
+    """
+
+    GENERAL_GLOBAL_CIPHER_TAG = 0xDB
+    # Long form length indicator: the following 2 bytes hold the length.
+    LONG_FORM_LENGTH_INDICATOR = 0x82
+
+    def __init__(self):
+        self._buffer = bytearray()
+
+    def get_all(self):
+        """
+        Remove complete frames from the buffer and yield them as hex strings.
+        :rtype generator:
+        """
+        for frame in iter(self._take_frame, None):
+            yield frame.hex()
+
+    def append(self, data):
+        """
+        Add binary telegram data to buffer.
+        :param bytes data: raw bytes read from the transport
+        """
+        self._buffer.extend(data)
+
+    def _take_frame(self):
+        """
+        Remove and return the first complete frame from the buffer, or None
+        when no complete frame is available yet.
+        :rtype bytes or None:
+        """
+        while True:
+            # Resync: discard anything before the first cipher tag.
+            start = self._buffer.find(self.GENERAL_GLOBAL_CIPHER_TAG)
+            if start == -1:
+                self._buffer.clear()
+                return None
+            if start > 0:
+                del self._buffer[:start]
+
+            # tag (1) + system title length (1) + system title (n)
+            #     + length indicator (1) + length (2)
+            if len(self._buffer) < 2:
+                return None
+            system_title_length = self._buffer[1]
+            header_length = 2 + system_title_length + 1 + 2
+            if len(self._buffer) < header_length:
+                return None
+
+            if self._buffer[2 + system_title_length] != self.LONG_FORM_LENGTH_INDICATOR:
+                # Not a frame we understand; drop this tag byte and resync.
+                del self._buffer[:1]
+                continue
+
+            payload_length = int.from_bytes(
+                self._buffer[3 + system_title_length:header_length], "big"
+            )
+            frame_length = header_length + payload_length
+            if len(self._buffer) < frame_length:
+                return None
+
+            frame = bytes(self._buffer[:frame_length])
+            del self._buffer[:frame_length]
+            return frame

--- a/dsmr_parser/exceptions.py
+++ b/dsmr_parser/exceptions.py
@@ -4,3 +4,14 @@ class ParseError(Exception):
 
 class InvalidChecksumError(ParseError):
     pass
+
+
+class DecryptionError(Exception):
+    """Raised when an encrypted telegram cannot be decrypted.
+
+    Deliberately not a :class:`ParseError`: a decryption failure on a
+    configured key is systematic (every telegram will fail the same way), so
+    callers should treat it as fatal and tear down the connection rather than
+    skip the telegram like a regular parse error.
+    """
+    pass

--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -6,10 +6,11 @@ from ctypes import c_ushort
 from decimal import Decimal
 
 from dlms_cosem.connection import XDlmsApduFactory
+from dlms_cosem.exceptions import DecryptionError as DlmsDecryptionError
 from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
 
 from dsmr_parser.objects import MBusObject, MBusObjectPeak, CosemObject, ProfileGenericObject, Telegram
-from dsmr_parser.exceptions import ParseError, InvalidChecksumError
+from dsmr_parser.exceptions import ParseError, InvalidChecksumError, DecryptionError
 from dsmr_parser.value_types import timestamp
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,15 @@ class TelegramParser(object):
                     logger.warning("Untested compression")
                 if apdu.security_control.broadcast_key:
                     logger.warning("Untested broadcast key")
-                telegram_data = apdu.to_plain_apdu(enc_key, auth_key).decode("ascii")
+                # A wrong key (or corrupted frame) fails GCM tag verification.
+                # Re-raise as our own DecryptionError, which callers should
+                # treat as fatal: with a configured key every telegram will
+                # fail identically, so the connection should be torn down
+                # rather than skipping telegram after telegram.
+                try:
+                    telegram_data = apdu.to_plain_apdu(enc_key, auth_key).decode("ascii")
+                except DlmsDecryptionError as err:
+                    raise DecryptionError("Failed to decrypt telegram: %s" % err)
             else:
                 try:
                     if unhexlify(telegram_data[0:2])[0] == GeneralGlobalCipher.TAG:

--- a/test/encryption_helpers.py
+++ b/test/encryption_helpers.py
@@ -1,0 +1,58 @@
+"""Test helpers for building encrypted (DLMS general-global-cipher) frames.
+
+These mirror the on-the-wire framing of encrypted DSMR telegrams as emitted by
+e.g. Luxembourg Smarty and Austrian Sagemcom meters, so tests can feed
+realistic binary frames through the readers/buffers.
+"""
+from binascii import unhexlify
+
+from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
+from dlms_cosem.security import SecurityControlField, encrypt
+
+
+def build_general_global_cipher_frame(
+    plain_text,
+    encryption_key,
+    authentication_key,
+    system_title=b"SYSTEMID",
+    invocation_counter=0x10000001,
+    security_suite=0,
+    authenticated=True,
+    encrypted=True,
+):
+    """Encrypt ``plain_text`` and wrap it in a general-global-cipher frame.
+
+    :param str plain_text: the plain DSMR telegram ('/...!XXXX\\r\\n')
+    :param str encryption_key: hex encryption key
+    :param str authentication_key: hex authentication key
+    :rtype: bytes
+    """
+    security_control = SecurityControlField(
+        security_suite=security_suite, authenticated=authenticated, encrypted=encrypted
+    )
+    ciphered = encrypt(
+        security_control=security_control,
+        key=unhexlify(encryption_key),
+        auth_key=unhexlify(authentication_key),
+        system_title=system_title,
+        invocation_counter=invocation_counter,
+        plain_text=plain_text.encode("ascii"),
+    )
+
+    security_control_bytes = security_control.to_bytes()
+    invocation_counter_bytes = invocation_counter.to_bytes(4, "big")
+
+    frame = bytearray()
+    frame.append(GeneralGlobalCipher.TAG)  # 0xDB
+    frame.append(len(system_title))
+    frame.extend(system_title)
+    frame.append(0x82)  # long form length indicator: 2 length bytes follow
+    frame.extend(
+        (len(security_control_bytes) + len(invocation_counter_bytes) + len(ciphered))
+        .to_bytes(2, "big")
+    )
+    frame.extend(security_control_bytes)
+    frame.extend(invocation_counter_bytes)
+    frame.extend(ciphered)
+
+    return bytes(frame)

--- a/test/test_encrypted_reader.py
+++ b/test/test_encrypted_reader.py
@@ -1,0 +1,164 @@
+"""End-to-end tests: encrypted binary frames flowing through the readers.
+
+These exercise the binary framing added on top of the general-global-cipher
+decryption, i.e. that a raw 0xDB DLMS frame arriving on the transport is
+assembled, decrypted and parsed (the path Home Assistant relies on via
+``create_dsmr_reader`` / ``DSMRProtocol``).
+"""
+from decimal import Decimal
+import unittest
+
+from dsmr_parser import telegram_specifications
+from dsmr_parser.clients.protocol import DSMRProtocol
+from dsmr_parser.clients.serial_ import SerialReader
+from dsmr_parser.clients.socket_ import SocketReader
+from dsmr_parser.clients.telegram_buffer import EncryptedTelegramBuffer, TelegramBuffer
+from dsmr_parser.exceptions import DecryptionError, ParseError
+from dsmr_parser.parsers import TelegramParser
+from test.encryption_helpers import build_general_global_cipher_frame
+from test.example_telegrams import TELEGRAM_SAGEMCOM_T210_D_R
+
+ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+AUTHENTICATION_KEY = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+
+def _frame():
+    return build_general_global_cipher_frame(
+        TELEGRAM_SAGEMCOM_T210_D_R, ENCRYPTION_KEY, AUTHENTICATION_KEY
+    )
+
+
+class _FakeTransport:
+    """Minimal asyncio transport stand-in that records close()."""
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _make_protocol(callback):
+    return DSMRProtocol(
+        None,
+        TelegramParser(telegram_specifications.SAGEMCOM_T210_D_R),
+        telegram_callback=callback,
+        encryption_key=ENCRYPTION_KEY,
+        authentication_key=AUTHENTICATION_KEY,
+    )
+
+
+class DSMRProtocolEncryptedTest(unittest.TestCase):
+
+    def test_selects_encrypted_buffer(self):
+        protocol = _make_protocol(lambda telegram: None)
+        self.assertIsInstance(protocol.telegram_buffer, EncryptedTelegramBuffer)
+
+    def test_full_frame_decrypts_and_parses(self):
+        telegrams = []
+        protocol = _make_protocol(telegrams.append)
+
+        protocol.data_received(_frame())
+
+        self.assertEqual(len(telegrams), 1)
+        self.assertEqual(
+            telegrams[0].ELECTRICITY_IMPORTED_TOTAL.value, Decimal("6545766")
+        )
+        self.assertEqual(
+            telegrams[0].CURRENT_ELECTRICITY_USAGE.value, Decimal("286")
+        )
+
+    def test_frame_chunked_across_data_received(self):
+        telegrams = []
+        protocol = _make_protocol(telegrams.append)
+        frame = _frame()
+
+        # Simulate the transport delivering the frame in several chunks.
+        protocol.data_received(frame[:50])
+        self.assertEqual(telegrams, [])
+        protocol.data_received(frame[50:200])
+        self.assertEqual(telegrams, [])
+        protocol.data_received(frame[200:])
+
+        self.assertEqual(len(telegrams), 1)
+        self.assertEqual(
+            telegrams[0].ELECTRICITY_IMPORTED_TOTAL.value, Decimal("6545766")
+        )
+
+    def test_wrong_key_tears_down_connection(self):
+        # A wrong key is unrecoverable: the protocol must record the failure,
+        # close the transport, and deliver no telegram (no spinning).
+        telegrams = []
+        protocol = DSMRProtocol(
+            None,
+            TelegramParser(telegram_specifications.SAGEMCOM_T210_D_R),
+            telegram_callback=telegrams.append,
+            encryption_key="CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",  # wrong
+            authentication_key=AUTHENTICATION_KEY,
+        )
+        transport = _FakeTransport()
+        protocol.connection_made(transport)
+
+        protocol.data_received(_frame())
+
+        self.assertEqual(telegrams, [])
+        self.assertIsInstance(protocol.decryption_error, DecryptionError)
+        self.assertTrue(transport.closed)
+
+
+class WrongKeyParseTest(unittest.TestCase):
+    """A wrong key/corrupted frame must surface as a fatal DecryptionError."""
+
+    def test_wrong_key_raises_decryption_error(self):
+        parser = TelegramParser(telegram_specifications.SAGEMCOM_T210_D_R)
+        with self.assertRaises(DecryptionError):
+            parser.parse(
+                _frame().hex(),
+                "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",  # wrong encryption key
+                AUTHENTICATION_KEY,
+            )
+
+    def test_decryption_error_is_not_parse_error(self):
+        # It must not be swallowed by generic `except ParseError` handlers.
+        self.assertFalse(issubclass(DecryptionError, ParseError))
+
+
+class ReaderBufferSelectionTest(unittest.TestCase):
+    """Readers must pick the binary buffer for encrypted specs and frame correctly."""
+
+    def test_serial_reader_uses_encrypted_buffer(self):
+        reader = SerialReader(
+            device="/dev/ttyUSB0",
+            serial_settings={},
+            telegram_specification=telegram_specifications.SAGEMCOM_T210_D_R,
+            encryption_key=ENCRYPTION_KEY,
+            authentication_key=AUTHENTICATION_KEY,
+        )
+        self.assertIsInstance(reader.telegram_buffer, EncryptedTelegramBuffer)
+        telegrams = list(reader._buffer_incoming(_frame()))
+        self.assertEqual(telegrams, [_frame().hex()])
+
+    def test_serial_reader_plain_spec_uses_text_buffer(self):
+        reader = SerialReader(
+            device="/dev/ttyUSB0",
+            serial_settings={},
+            telegram_specification=telegram_specifications.V5,
+        )
+        self.assertIsInstance(reader.telegram_buffer, TelegramBuffer)
+
+    def test_socket_reader_uses_encrypted_buffer(self):
+        reader = SocketReader(
+            host="localhost",
+            port=2001,
+            telegram_specification=telegram_specifications.SAGEMCOM_T210_D_R,
+            encryption_key=ENCRYPTION_KEY,
+            authentication_key=AUTHENTICATION_KEY,
+        )
+        self.assertIsInstance(reader.telegram_buffer, EncryptedTelegramBuffer)
+        # Socket data is binary and must not be line-split for encrypted frames.
+        telegrams = list(reader._buffer_incoming(_frame()))
+        self.assertEqual(telegrams, [_frame().hex()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_encrypted_reader.py
+++ b/test/test_encrypted_reader.py
@@ -158,4 +158,3 @@ class ReaderBufferSelectionTest(unittest.TestCase):
         # Socket data is binary and must not be line-split for encrypted frames.
         telegrams = list(reader._buffer_incoming(_frame()))
         self.assertEqual(telegrams, [_frame().hex()])
-

--- a/test/test_encrypted_reader.py
+++ b/test/test_encrypted_reader.py
@@ -159,6 +159,3 @@ class ReaderBufferSelectionTest(unittest.TestCase):
         telegrams = list(reader._buffer_incoming(_frame()))
         self.assertEqual(telegrams, [_frame().hex()])
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_encrypted_telegram_buffer.py
+++ b/test/test_encrypted_telegram_buffer.py
@@ -73,4 +73,3 @@ class EncryptedTelegramBufferTest(unittest.TestCase):
         buffer.append(b"\xdb\x08")  # only tag + system title length
 
         self.assertEqual(list(buffer.get_all()), [])
-

--- a/test/test_encrypted_telegram_buffer.py
+++ b/test/test_encrypted_telegram_buffer.py
@@ -1,0 +1,79 @@
+"""Tests for EncryptedTelegramBuffer (binary DLMS general-global-cipher framing)."""
+import unittest
+
+from dsmr_parser.clients.telegram_buffer import EncryptedTelegramBuffer
+from test.encryption_helpers import build_general_global_cipher_frame
+from test.example_telegrams import TELEGRAM_SAGEMCOM_T210_D_R
+
+ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+AUTHENTICATION_KEY = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+
+def _frame(invocation_counter=0x10000001):
+    return build_general_global_cipher_frame(
+        TELEGRAM_SAGEMCOM_T210_D_R,
+        ENCRYPTION_KEY,
+        AUTHENTICATION_KEY,
+        invocation_counter=invocation_counter,
+    )
+
+
+class EncryptedTelegramBufferTest(unittest.TestCase):
+
+    def test_single_complete_frame(self):
+        frame = _frame()
+        buffer = EncryptedTelegramBuffer()
+        buffer.append(frame)
+
+        telegrams = list(buffer.get_all())
+
+        self.assertEqual(telegrams, [frame.hex()])
+
+    def test_frame_split_across_appends(self):
+        frame = _frame()
+        buffer = EncryptedTelegramBuffer()
+
+        # Feed the frame byte-by-byte; only the final byte completes it.
+        for byte in frame[:-1]:
+            buffer.append(bytes([byte]))
+            self.assertEqual(list(buffer.get_all()), [])
+        buffer.append(bytes([frame[-1]]))
+
+        self.assertEqual(list(buffer.get_all()), [frame.hex()])
+
+    def test_two_back_to_back_frames(self):
+        frame1 = _frame(invocation_counter=0x10000001)
+        frame2 = _frame(invocation_counter=0x10000002)
+        buffer = EncryptedTelegramBuffer()
+        buffer.append(frame1 + frame2)
+
+        telegrams = list(buffer.get_all())
+
+        self.assertEqual(telegrams, [frame1.hex(), frame2.hex()])
+
+    def test_resync_on_leading_garbage(self):
+        frame = _frame()
+        buffer = EncryptedTelegramBuffer()
+        # Random bytes before the real frame (none of which is 0xDB).
+        buffer.append(b"\x00\x01\x02garbage" + frame)
+
+        telegrams = list(buffer.get_all())
+
+        self.assertEqual(telegrams, [frame.hex()])
+
+    def test_incomplete_frame_yields_nothing(self):
+        frame = _frame()
+        buffer = EncryptedTelegramBuffer()
+        buffer.append(frame[:20])  # header + a bit, but not the full payload
+
+        self.assertEqual(list(buffer.get_all()), [])
+
+    def test_partial_header_yields_nothing(self):
+        buffer = EncryptedTelegramBuffer()
+        buffer.append(b"\xdb\x08")  # only tag + system title length
+
+        self.assertEqual(list(buffer.get_all()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_encrypted_telegram_buffer.py
+++ b/test/test_encrypted_telegram_buffer.py
@@ -74,6 +74,3 @@ class EncryptedTelegramBufferTest(unittest.TestCase):
 
         self.assertEqual(list(buffer.get_all()), [])
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_parse_msn.py
+++ b/test/test_parse_msn.py
@@ -12,13 +12,12 @@ from decimal import Decimal
 
 import unittest
 
-from dlms_cosem.exceptions import DecryptionError
 from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
 from dlms_cosem.security import SecurityControlField, encrypt
 
 from dsmr_parser import obis_references as obis
 from dsmr_parser import telegram_specifications
-from dsmr_parser.exceptions import ParseError
+from dsmr_parser.exceptions import ParseError, DecryptionError
 from dsmr_parser.parsers import TelegramParser
 from test.example_telegrams import TELEGRAM_LUXEMBOURG_SMARTY
 

--- a/test/test_parse_sagemcom_t210_d_r.py
+++ b/test/test_parse_sagemcom_t210_d_r.py
@@ -3,12 +3,11 @@ from copy import deepcopy
 
 import unittest
 
-from dlms_cosem.exceptions import DecryptionError
 from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
 from dlms_cosem.security import SecurityControlField, encrypt
 
 from dsmr_parser import telegram_specifications
-from dsmr_parser.exceptions import ParseError
+from dsmr_parser.exceptions import DecryptionError, ParseError
 from dsmr_parser.parsers import TelegramParser
 from test.example_telegrams import TELEGRAM_SAGEMCOM_T210_D_R
 
@@ -69,6 +68,8 @@ class TelegramParserEncryptedTest(unittest.TestCase):
         generated[150] = 0x00
         generated = generated.hex()
 
+        # Decryption failures are re-raised as a fatal DecryptionError so
+        # callers tear down the connection instead of skipping telegrams.
         with self.assertRaises(DecryptionError):
             parser.parse(generated, self.DUMMY_ENCRYPTION_KEY, self.DUMMY_AUTHENTICATION_KEY)
 


### PR DESCRIPTION
## Binary framing for encrypted telegrams over the serial/network readers

#178 (released in v1.8.0) added encrypted (`MSn` / `SAGEMCOM_T210_D_R`) telegram
support to `TelegramParser.parse()`, but encrypted telegrams still cannot flow
through the **readers**. They are binary DLMS frames (starting with the
general-global-cipher tag `0xDB`), whereas the readers ascii-decode incoming
bytes and frame via a regex that only matches the plain `/…!XXXX` telegram — so
encrypted frames are dropped before they ever reach `parse()`. This is the path
Home Assistant uses (`create_dsmr_reader` / `DSMRProtocol`).

This PR adds the transport layer to actually receive them:

- **`EncryptedTelegramBuffer`** — frames binary DLMS packets by their
  self-describing length header (handles partial frames, back-to-back frames,
  resync on leading garbage); yields complete frames as hex.
- **Reader wiring** — `SerialReader`, `AsyncSerialReader`, `SocketReader` and
  `DSMRProtocol` select the binary buffer when the spec has
  `general_global_cipher`, buffer raw bytes instead of ascii-decoding, and
  forward the keys to `parse()`.
- **Fatal decryption errors** — a distinct `dsmr_parser.exceptions.DecryptionError`
  (not a `ParseError`): a wrong key is systematic, so `DSMRProtocol` records it
  and tears the connection down rather than spinning on broken telegrams.

### Verification

Verified end-to-end **together with its companion PR** (the
`authentication_key=None` opt-in) by a Home Assistant user against a **real
Luxembourg Smarty** meter — binary frames are assembled off a live serial/TCP
stream, decrypted and parsed into entities. See #185 for the
authentication-key finding (the spec's fixed public auth key did not work
against the real meter).
