### PR TITLE
Opt-in: decrypt encrypted telegrams without verifying the GCM tag

### DIFF
--- a/dsmr_parser/parsers.py
+++ b/dsmr_parser/parsers.py
@@ -5,7 +5,9 @@ from binascii import unhexlify
 from ctypes import c_ushort
 from decimal import Decimal
 
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from dlms_cosem.connection import XDlmsApduFactory
+from dlms_cosem.exceptions import DecryptionError
 from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
 
 from dsmr_parser.objects import MBusObject, MBusObjectPeak, CosemObject, ProfileGenericObject, Telegram
@@ -13,6 +15,30 @@ from dsmr_parser.exceptions import ParseError, InvalidChecksumError
 from dsmr_parser.value_types import timestamp
 
 logger = logging.getLogger(__name__)
+
+
+def _decrypt_without_verification(apdu, encryption_key):
+    """Decrypt a general-global-cipher APDU without verifying the GCM tag.
+
+    GCM decryption is AES-CTR with the counter starting at inc32(J0); for the
+    96-bit DLMS IV that is system_title || invocation_counter || 0x00000002.
+    This recovers the plaintext using only the encryption key, ignoring the
+    authentication tag. It is used when the caller passes ``authentication_key=
+    None`` -- e.g. for meters whose authentication key is unknown or wrong, like
+    the Luxembourg Smarty (see ESPHome's dsmr component, which decrypts the same
+    way). Integrity is then provided by the telegram's own CRC.
+
+    :param apdu: a decoded GeneralGlobalCipher APDU
+    :param bytes encryption_key: the 16 byte encryption key
+    :rtype: bytes
+    """
+    iv = apdu.system_title + apdu.invocation_counter.to_bytes(4, "big")
+    initial_counter = iv + (2).to_bytes(4, "big")
+    ciphertext = apdu.ciphered_text[:-12]  # strip the 12 byte GCM tag
+    decryptor = Cipher(
+        algorithms.AES(encryption_key), modes.CTR(initial_counter)
+    ).decryptor()
+    return decryptor.update(ciphertext) + decryptor.finalize()
 
 
 class TelegramParser(object):
@@ -50,13 +76,6 @@ class TelegramParser(object):
         if "general_global_cipher" in self.telegram_specification:
             if self.telegram_specification["general_global_cipher"]:
                 enc_key = unhexlify(encryption_key)
-                # Use the spec's embedded authentication key if the caller did not
-                # supply one. Some meters (e.g. Luxembourg Smarty/MSN) use a fixed
-                # public authentication key defined in the official specification.
-                effective_auth_key = authentication_key or self.telegram_specification.get(
-                    "authentication_key", ""
-                )
-                auth_key = unhexlify(effective_auth_key)
                 telegram_data = unhexlify(telegram_data)
                 apdu = XDlmsApduFactory.apdu_from_bytes(apdu_bytes=telegram_data)
                 if apdu.security_control.security_suite != 0:
@@ -69,7 +88,32 @@ class TelegramParser(object):
                     logger.warning("Untested compression")
                 if apdu.security_control.broadcast_key:
                     logger.warning("Untested broadcast key")
-                telegram_data = apdu.to_plain_apdu(enc_key, auth_key).decode("ascii")
+                if authentication_key is None:
+                    # Opt-in: decrypt without verifying the GCM authentication
+                    # tag, using only the encryption key, and rely on the
+                    # telegram CRC for integrity. Needed for meters whose
+                    # authentication key is unknown/wrong (e.g. the Luxembourg
+                    # Smarty -- ESPHome decrypts the same way). A wrong
+                    # encryption key yields non-ASCII garbage / no leading '/'.
+                    try:
+                        telegram_data = _decrypt_without_verification(
+                            apdu, enc_key
+                        ).decode("ascii")
+                    except (UnicodeDecodeError, ValueError):
+                        telegram_data = ""
+                    if not telegram_data.startswith("/"):
+                        raise DecryptionError(
+                            "Unable to decrypt telegram; wrong encryption key?"
+                        )
+                else:
+                    # Use the spec's embedded authentication key if the caller did not
+                    # supply one. Some meters (e.g. Luxembourg Smarty/MSN) use a fixed
+                    # public authentication key defined in the official specification.
+                    effective_auth_key = authentication_key or self.telegram_specification.get(
+                        "authentication_key", ""
+                    )
+                    auth_key = unhexlify(effective_auth_key)
+                    telegram_data = apdu.to_plain_apdu(enc_key, auth_key).decode("ascii")
             else:
                 try:
                     if unhexlify(telegram_data[0:2])[0] == GeneralGlobalCipher.TAG:

--- a/test/test_decrypt_without_verification.py
+++ b/test/test_decrypt_without_verification.py
@@ -1,0 +1,87 @@
+"""Tests for the authentication_key=None opt-in (decrypt without verification).
+
+When ``authentication_key=None`` is passed, the parser decrypts a
+general-global-cipher telegram using only the encryption key and does not
+verify the GCM authentication tag (integrity comes from the telegram CRC).
+This is needed for meters whose authentication key is unknown or differs from
+the spec's (e.g. the Luxembourg Smarty), and matches what ESPHome does.
+"""
+from binascii import unhexlify
+from decimal import Decimal
+
+import unittest
+
+from dlms_cosem.exceptions import DecryptionError
+from dlms_cosem.protocol.xdlms import GeneralGlobalCipher
+from dlms_cosem.security import SecurityControlField, encrypt
+
+from dsmr_parser import obis_references as obis
+from dsmr_parser import telegram_specifications
+from dsmr_parser.parsers import TelegramParser
+from test.example_telegrams import TELEGRAM_LUXEMBOURG_SMARTY
+
+ENCRYPTION_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+# An authentication key the caller does NOT know -- as on a real meter whose
+# auth key is not the fixed one in the spec.
+METER_AUTHENTICATION_KEY = "0102030405060708090A0B0C0D0E0F10"
+
+
+def _build_frame(encryption_key, authentication_key):
+    security_control = SecurityControlField(
+        security_suite=0, authenticated=True, encrypted=True
+    )
+    system_title = b"SYSTEMID"
+    invocation_counter = int.from_bytes(bytes.fromhex("10000001"), "big")
+    encrypted_data = encrypt(
+        security_control=security_control,
+        key=unhexlify(encryption_key),
+        auth_key=unhexlify(authentication_key),
+        system_title=system_title,
+        invocation_counter=invocation_counter,
+        plain_text=TELEGRAM_LUXEMBOURG_SMARTY.encode("ascii"),
+    )
+    frame = bytearray(GeneralGlobalCipher.TAG.to_bytes(1, "big"))
+    frame.extend(len(system_title).to_bytes(1, "big"))
+    frame.extend(system_title)
+    frame.append(0x82)
+    sc = security_control.to_bytes()
+    ic = invocation_counter.to_bytes(4, "big")
+    frame.extend((len(sc) + len(ic) + len(encrypted_data)).to_bytes(2, "big"))
+    frame.extend(sc)
+    frame.extend(ic)
+    frame.extend(encrypted_data)
+    return frame.hex()
+
+
+class DecryptWithoutVerificationTest(unittest.TestCase):
+
+    def test_decrypts_regardless_of_authentication_key(self):
+        # Encrypted with an authentication key the caller does not have.
+        frame = _build_frame(ENCRYPTION_KEY, METER_AUTHENTICATION_KEY)
+        parser = TelegramParser(telegram_specifications.MSN)
+
+        result = parser.parse(frame, ENCRYPTION_KEY, authentication_key=None)
+
+        self.assertEqual(
+            result[obis.ELECTRICITY_IMPORTED_TOTAL].value, Decimal("273.764")
+        )
+
+    def test_wrong_encryption_key_is_rejected(self):
+        frame = _build_frame(ENCRYPTION_KEY, METER_AUTHENTICATION_KEY)
+        parser = TelegramParser(telegram_specifications.MSN)
+
+        with self.assertRaises(DecryptionError):
+            parser.parse(frame, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC", authentication_key=None)
+
+    def test_authenticated_default_still_verifies(self):
+        # With a string authentication key the GCM tag is still verified: a
+        # wrong key must fail (the default behaviour is unchanged).
+        frame = _build_frame(ENCRYPTION_KEY, METER_AUTHENTICATION_KEY)
+        parser = TelegramParser(telegram_specifications.MSN)
+
+        with self.assertRaises(DecryptionError):
+            parser.parse(frame, ENCRYPTION_KEY, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Opt-in: decrypt without verifying the GCM tag (`authentication_key=None`)

Companion to #184 (binary framing). Both were verified together by a Home
Assistant user against a **real Luxembourg Smarty** meter.

### The problem: the embedded authentication key does not work on real meters

#178 embeds a fixed "public" authentication key for the Luxembourg Smarty
(`00112233445566778899AABBCCDDEEFF`, from the spec) and does authenticated
GCM decryption with it. Against a **real** Smarty meter this **fails even with
the correct encryption key** — the user supplied a valid encryption key and got
an "invalid key"/decryption error. The meter's actual authentication key is not
that value (it looks like a spec *example*), so GCM tag verification never
passes. Synthetic round-trip tests don't catch this because they encrypt and
decrypt with the same key.

### The change

Passing `authentication_key=None` decrypts using **only the encryption key**,
without verifying the GCM tag (AES-CTR; the IV/counter are derived the same way
GCM does), and relies on the telegram's **CRC** for integrity. With this, the
real meter decrypts correctly using just the encryption key. A wrong encryption
key still yields non-ASCII garbage / no leading `/` and raises `DecryptionError`.

This is **opt-in and backward compatible**: a string `authentication_key`
(including `""`) keeps the existing authenticated behaviour with the GCM tag
verified, so #178's default is unchanged. (Tests assert both: `None` decrypts
regardless of the meter's auth key, and a wrong string auth key still fails.)

### Why skipping verification is acceptable here

For a smart-meter P1 port this is the same trade-off ESPHome's `dsmr` component
already makes (it never verifies the tag):

- The telegram already carries a **CRC**, which catches accidental corruption
  (line noise, framing) just as well as the GCM tag does.
- The only thing GCM authentication adds over the CRC is detecting a malicious
  **active** attacker who can modify the wire in real time — which, for a
  read-only telemetry cable between a meter and a local device in someone's
  home, is out of scope.
- The integration that needs this (Home Assistant) only ever reads telemetry,
  so it opts in via `authentication_key=None`; nothing that wants authenticated
  decryption has to change.
