### PR TITLE
Make create_tcp_dsmr_reader a thin wrapper around create_dsmr_reader

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+**Unreleased**
+
+- ``create_tcp_dsmr_reader`` is now a thin wrapper around ``create_dsmr_reader`` (using a ``socket://`` URL); both establish the exact same TCP connection. ``create_dsmr_reader`` gained a ``keep_alive_interval`` argument so the keep-alive watchdog can be used on either entry point. Default behaviour is unchanged.
+- The event loop is now resolved with ``asyncio.get_running_loop()`` instead of the deprecated ``asyncio.get_event_loop()``. Both readers must be called from within a running event loop unless an explicit ``loop`` is passed.
+
 **1.8.0** (2026-06-08)
 
 - Add encrypted telegram support for MSn (Luxembourg Smarty) and SAGEMCOM_T210_D_R (`PR #178 <https://github.com/ndokter/dsmr_parser/pull/178>`_ by `Arvoreen75 <https://github.com/Arvoreen75>`_) and  `skrutzler <https://github.com/skrutzler>`_)

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -73,10 +73,23 @@ def _create_dsmr_protocol(dsmr_version, telegram_callback, protocol, loop=None, 
 
 
 def create_dsmr_reader(port, dsmr_version, telegram_callback, loop=None,
+                       keep_alive_interval=None,
                        encryption_key="", authentication_key=""):
-    """Creates a DSMR asyncio protocol coroutine using serial port."""
+    """Creates a DSMR asyncio protocol coroutine using serial port.
+
+    The ``port`` may be a local serial device (e.g. ``/dev/ttyUSB0``) or a
+    network URL handled by serialx (e.g. ``socket://host:port``). Pass
+    ``keep_alive_interval`` to enable the keep-alive watchdog, which detects
+    and recovers from half-open network connections that would otherwise stall
+    silently.
+
+    Must be called from within a running event loop unless ``loop`` is given.
+    """
+    if loop is None:
+        loop = asyncio.get_running_loop()
     protocol, serial_settings = create_dsmr_protocol(
-        dsmr_version, telegram_callback, loop=None,
+        dsmr_version, telegram_callback, loop=loop,
+        keep_alive_interval=keep_alive_interval,
         encryption_key=encryption_key, authentication_key=authentication_key)
     serial_settings['url'] = port
 
@@ -88,15 +101,15 @@ def create_tcp_dsmr_reader(host, port, dsmr_version,
                            telegram_callback, loop=None,
                            keep_alive_interval=None,
                            encryption_key="", authentication_key=""):
-    """Creates a DSMR asyncio protocol coroutine using TCP connection."""
-    if not loop:
-        loop = asyncio.get_event_loop()
-    protocol, _ = create_dsmr_protocol(
-        dsmr_version, telegram_callback, loop=loop,
-        keep_alive_interval=keep_alive_interval,
+    """Creates a DSMR asyncio protocol coroutine using a TCP connection.
+
+    This is a thin wrapper around :func:`create_dsmr_reader` using a
+    ``socket://`` URL; both establish the exact same TCP connection.
+    """
+    return create_dsmr_reader(
+        f'socket://{host}:{port}', dsmr_version, telegram_callback,
+        loop=loop, keep_alive_interval=keep_alive_interval,
         encryption_key=encryption_key, authentication_key=authentication_key)
-    conn = loop.create_connection(protocol, host, port)
-    return conn
 
 
 class DSMRProtocol(asyncio.Protocol):

--- a/test/test_protocol.py
+++ b/test/test_protocol.py
@@ -1,9 +1,13 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import unittest
 
 from dsmr_parser import obis_references as obis
-from dsmr_parser.clients.protocol import create_dsmr_protocol
+from dsmr_parser.clients import protocol as protocol_module
+from dsmr_parser.clients.protocol import (
+    create_dsmr_protocol,
+    create_tcp_dsmr_reader,
+)
 from dsmr_parser.objects import Telegram
 
 TELEGRAM_V2_2 = (
@@ -71,3 +75,23 @@ class ProtocolTest(unittest.TestCase):
         mock_transport.close.assert_called_once()
 
         self.protocol.connection_lost(None)
+
+
+class CreateTcpDsmrReaderTest(unittest.TestCase):
+
+    def test_delegates_to_create_dsmr_reader(self):
+        """It builds a socket:// URL and forwards every argument; the
+        watchdog itself is covered by ProtocolTest.test_receive_packet."""
+        conn = Mock()
+        with patch.object(protocol_module, 'create_serial_connection', conn):
+            create_tcp_dsmr_reader('host.example', 1234, '2.2',
+                                   telegram_callback=Mock(), loop=Mock(),
+                                   keep_alive_interval=1,
+                                   encryption_key='abc',
+                                   authentication_key='def')
+
+        assert conn.call_args.kwargs['url'] == 'socket://host.example:1234'
+        protocol = conn.call_args[0][1]()
+        assert protocol._keep_alive_interval == 1
+        assert protocol._encryption_key == 'abc'
+        assert protocol._authentication_key == 'def'


### PR DESCRIPTION
## Why

Since the migration to serialx, `create_dsmr_reader` already accepts network
URLs (e.g. `socket://host:port`) — serialx routes those through a TCP transport.
That means `create_tcp_dsmr_reader` and `create_dsmr_reader` now establish the
*exact same* connection for TCP. Since we accept network URLs via the normal
route too, the two functions should be treated the same rather than maintained
as separate code paths.

This also unblocks a concrete use case: **ESPHome serial proxies** want to
leverage the keep-alive watchdog, but their connection URL uses a different
protocol scheme and a query parameter to select the port — so it doesn't fit
the `host, port` shape of `create_tcp_dsmr_reader`. Routing everything through
the URL-based `create_dsmr_reader` (which now also exposes `keep_alive_interval`)
lets those consumers pass their own URL and still get keep-alive.

## What

- `create_tcp_dsmr_reader` is now a thin wrapper that builds a `socket://host:port`
  URL and forwards to `create_dsmr_reader`, removing the duplicated connection logic.
- `create_dsmr_reader` gains a `keep_alive_interval` argument so the keep-alive
  watchdog is available on either entry point.
- The event loop is resolved with `asyncio.get_running_loop()` instead of the
  deprecated `get_event_loop()`. This also fixes a latent crash where
  `create_dsmr_reader`, called without a loop, passed `None` into serialx (whose
  transport calls `loop.create_future()` in its constructor).

## Compatibility

Non-breaking: `keep_alive_interval` defaults to `None` (watchdog off) on both
functions, exactly as before. Both readers must now be called from within a
running event loop unless an explicit `loop` is passed (previously
`get_event_loop()` would lazily create one — the deprecated behaviour).