### PR TITLE
Only try to parse incoming data when checksum has arrived

### DIFF
--- a/dsmr_parser/clients/telegram_buffer.py
+++ b/dsmr_parser/clients/telegram_buffer.py
@@ -23,6 +23,11 @@ class TelegramBuffer(object):
         Remove complete telegrams from buffer and yield them.
         :rtype generator:
         """
+
+        # Don't waste time parsing until the checksum has arrived
+        if "!" not in self._buffer:
+            return
+
         for telegram in _FIND_TELEGRAMS_REGEX.findall(self._buffer):
             self._remove(telegram)
             yield telegram


### PR DESCRIPTION
The recent migration to serialx I think exposed a small issue with the parsing loop. By default serialx sets `low_latency=True` for all adapters, which can break incoming messages up into smaller chunks and cause parsing loops to run more often.

This PR avoids running the regex parser on the data buffer if the checksum line starting with `!` has not arrived yet. I don't have access to an energy meter to actually test this change but the test suite passes.

---

Related: https://github.com/home-assistant/core/issues/173474