### PR TITLE
Set low latency to false to avoid CPU spike

### DIFF
--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -92,7 +92,7 @@ def create_dsmr_reader(port, dsmr_version, telegram_callback, loop=None,
         keep_alive_interval=keep_alive_interval,
         encryption_key=encryption_key, authentication_key=authentication_key)
     serial_settings['url'] = port
-
+    serial_settings['low_latency'] = False
     conn = create_serial_connection(loop, protocol, **serial_settings)
     return conn
 


### PR DESCRIPTION
I am impacted by https://github.com/home-assistant/core/issues/173474 in which high CPU usage was reported since 2026.6.0 
The low latency flag was the culprit which defaults to True if not explicitly provided. 

Forcing low_latency = False when calling create_serial_connection method of serialx solves the problem for me and /sys/bus/usb-serial/devices/ttyUSB0/latency_timer stays at 16

Tested with 2026.7.1 and latest release of this package. 
