### PR TITLE
Detect closed socket connection

### DIFF
--- a/dsmr_parser/clients/socket_.py
+++ b/dsmr_parser/clients/socket_.py
@@ -65,6 +65,10 @@ class SocketReader(object):
                     logger.error("Socket timeout occurred, exiting")
                     break
 
+                if len(data) == 0:
+                    logger.error("Socket connection closed, exiting")
+                    break
+
                 for telegram in self._buffer_incoming(data):
                     try:
                         yield self.telegram_parser.parse(


### PR DESCRIPTION
While I was testing other things, I noticed that the `SocketReader.read()` function stopped outputting data when the network connection was lost.
It also causes 100% CPU load through an infinite for loop.

`socket.read()` returns a packet of 0 bytes if the connection is lost and will not raise an error.
A simple length check ensures that the closed connection is detected.