### PR TITLE
Convert "complex" (too long) if-elif-else to dict

### DIFF
--- a/dsmr_parser/__main__.py
+++ b/dsmr_parser/__main__.py
@@ -3,7 +3,7 @@ import argparse
 import asyncio
 import logging
 
-from dsmr_parser.clients import create_dsmr_reader, create_tcp_dsmr_reader
+from dsmr_parser.clients import create_dsmr_reader, create_tcp_dsmr_reader, DSMR_VERSIONS
 
 
 def console():
@@ -16,8 +16,8 @@ def console():
                         help='alternatively connect using TCP host.')
     parser.add_argument('--port', default=None,
                         help='TCP port to use for connection')
-    parser.add_argument('--version', default='2.2', choices=['2.2', '4', '5', '5B', '5L', '5S', 'Q3D'],
-                        help='DSMR version (2.2, 4, 5, 5B, 5L, 5S, Q3D)')
+    parser.add_argument('--version', default='2.2', choices=list(DSMR_VERSIONS.keys()),
+                        help='DSMR version')
     parser.add_argument('--verbose', '-v', action='count')
 
     args = parser.parse_args()

--- a/dsmr_parser/clients/__init__.py
+++ b/dsmr_parser/clients/__init__.py
@@ -3,4 +3,4 @@ from dsmr_parser.clients.settings import SERIAL_SETTINGS_V2_2, \
 from dsmr_parser.clients.serial_ import SerialReader, AsyncSerialReader
 from dsmr_parser.clients.socket_ import SocketReader
 from dsmr_parser.clients.protocol import create_dsmr_protocol, \
-    create_dsmr_reader, create_tcp_dsmr_reader
+    create_dsmr_reader, create_tcp_dsmr_reader, DSMR_VERSIONS

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -6,12 +6,10 @@ import logging
 
 from serialx import create_serial_connection
 
-from dsmr_parser import telegram_specifications
+from dsmr_parser.dsmr_versions import DSMR_VERSIONS
 from dsmr_parser.clients.telegram_buffer import TelegramBuffer, EncryptedTelegramBuffer
 from dsmr_parser.exceptions import ParseError, InvalidChecksumError, DecryptionError
 from dsmr_parser.parsers import TelegramParser
-from dsmr_parser.clients.settings import SERIAL_SETTINGS_V2_2, \
-    SERIAL_SETTINGS_V4, SERIAL_SETTINGS_V5
 
 
 def create_dsmr_protocol(dsmr_version, telegram_callback, loop=None, **kwargs):
@@ -21,51 +19,13 @@ def create_dsmr_protocol(dsmr_version, telegram_callback, loop=None, **kwargs):
     return protocol
 
 
-# pylama noqa - because of "complex" (too long) if-elif-else.
-# Match - case might be a solution but it is not available in <3.10
 def _create_dsmr_protocol(dsmr_version, telegram_callback, protocol, loop=None, **kwargs):  # noqa
     """Creates a DSMR asyncio protocol."""
-
-    if dsmr_version == '2.2':
-        specification = telegram_specifications.V2_2
-        serial_settings = SERIAL_SETTINGS_V2_2
-    elif dsmr_version == '4':
-        specification = telegram_specifications.V4
-        serial_settings = SERIAL_SETTINGS_V4
-    elif dsmr_version == '4+':
-        specification = telegram_specifications.V5
-        serial_settings = SERIAL_SETTINGS_V4
-    elif dsmr_version == '5':
-        specification = telegram_specifications.V5
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == '5B':
-        specification = telegram_specifications.BELGIUM_FLUVIUS
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == "5L":
-        specification = telegram_specifications.LUXEMBOURG_SMARTY
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == "5S":
-        specification = telegram_specifications.SWEDEN
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == "Q3D":
-        specification = telegram_specifications.Q3D
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == 'ISKRA_IE':
-        specification = telegram_specifications.ISKRA_IE
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == '5EONHU':
-        specification = telegram_specifications.EON_HUNGARY
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == 'MSn':
-        specification = telegram_specifications.MSN
-        serial_settings = SERIAL_SETTINGS_V5
-    elif dsmr_version == 'SAGEMCOM_T210_D_R':
-        specification = telegram_specifications.SAGEMCOM_T210_D_R
-        serial_settings = SERIAL_SETTINGS_V5
-    else:
+    if dsmr_version not in DSMR_VERSIONS:
         raise NotImplementedError("No telegram parser found for version: %s",
                                   dsmr_version)
 
+    specification, serial_settings = DSMR_PROTOCOL_MAPPING[dsmr_version]
     protocol = partial(protocol, loop, TelegramParser(specification),
                        telegram_callback=telegram_callback, **kwargs)
 

--- a/dsmr_parser/clients/protocol.py
+++ b/dsmr_parser/clients/protocol.py
@@ -25,7 +25,7 @@ def _create_dsmr_protocol(dsmr_version, telegram_callback, protocol, loop=None, 
         raise NotImplementedError("No telegram parser found for version: %s",
                                   dsmr_version)
 
-    specification, serial_settings = DSMR_PROTOCOL_MAPPING[dsmr_version]
+    specification, serial_settings = DSMR_VERSIONS[dsmr_version]
     protocol = partial(protocol, loop, TelegramParser(specification),
                        telegram_callback=telegram_callback, **kwargs)
 

--- a/dsmr_parser/dsmr_versions.py
+++ b/dsmr_parser/dsmr_versions.py
@@ -1,0 +1,20 @@
+"""List of supported DSMR versions."""
+
+from dsmr_parser import telegram_specifications
+from dsmr_parser.clients.settings import SERIAL_SETTINGS_V2_2, \
+    SERIAL_SETTINGS_V4, SERIAL_SETTINGS_V5
+
+DSMR_VERSIONS = {
+    '2.2': (telegram_specifications.V2_2, SERIAL_SETTINGS_V2_2),
+    '4': (telegram_specifications.V4, SERIAL_SETTINGS_V4),
+    '4+': (telegram_specifications.V5, SERIAL_SETTINGS_V4),
+    '5': (telegram_specifications.V5, SERIAL_SETTINGS_V5),
+    '5B': (telegram_specifications.BELGIUM_FLUVIUS, SERIAL_SETTINGS_V5),
+    '5L': (telegram_specifications.LUXEMBOURG_SMARTY, SERIAL_SETTINGS_V5),
+    '5S': (telegram_specifications.SWEDEN, SERIAL_SETTINGS_V5),
+    'Q3D': (telegram_specifications.Q3D, SERIAL_SETTINGS_V5),
+    'ISKRA_IE': (telegram_specifications.ISKRA_IE, SERIAL_SETTINGS_V5),
+    '5EONHU': (telegram_specifications.EON_HUNGARY, SERIAL_SETTINGS_V5),
+    'MSn': (telegram_specifications.MSN, SERIAL_SETTINGS_V5),
+    'SAGEMCOM_T210_D_R': (telegram_specifications.SAGEMCOM_T210_D_R, SERIAL_SETTINGS_V5),
+}


### PR DESCRIPTION
This PR replaces the long if-elif-else inside dsmr_parser/clients/protocol.py by a separate dict.
As a result, other programs that use this module can now see which dsmr_version options are available (including dsmr_console).